### PR TITLE
feat: add plugin @umijs/plugin-analatics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /yarn.lock
 /packages/@umijs/*/yarn.lock
 .DS_Store
+**/dist
+.umi
+.umi-production

--- a/packages/@umijs/analytics/README.md
+++ b/packages/@umijs/analytics/README.md
@@ -1,4 +1,4 @@
-# @umijs/analytics
+# @umijs/plugin-analytics
 
 analytics for baidu tongji and google analytics
 
@@ -9,7 +9,7 @@ Configure in `.umirc.js`,
 ```js
 export default {
   plugins: [
-    ['@umijs/analytics', {
+    ['@umijs/plugin-analytics', {
       ga:'google analytics code',
       baidu: '5a66cxxxxxxxxxx9e13',
     }],

--- a/packages/@umijs/analytics/README.md
+++ b/packages/@umijs/analytics/README.md
@@ -1,0 +1,40 @@
+# @umijs/analytics
+
+analytics for baidu tongji and google analytics
+
+## Usage
+
+Configure in `.umirc.js`,
+
+```js
+export default {
+  plugins: [
+    ['@umijs/analytics', {
+      ga:'google analytics code',
+      baidu: '5a66cxxxxxxxxxx9e13',
+      judge: ()=>true // true or false
+    }],
+  ],
+}
+```
+
+## Code
+
+e.g `hm.src = "https://hm.baidu.com/hm.js?5a66c03cxxxxxx554f2b9e13";`
+baidu is `5a66c03cxxxxxx554f2b9e13`
+
+## 百度事件跟踪
+
+> 在JS中调用事件跟踪代码。
+> `window._hmt.push(['_trackEvent', category, action, opt_label, opt_value]);`
+
+| 参数 | 说明 |
+|  :-  | :-:  |
+| category | 要监控的目标的类型名称，通常是同一组目标的名字，比如"视频"、"音乐"、"软件"、"游戏"等等。该项必填，不填、填"-"的事件会被抛弃。 |
+| action | 用户跟目标交互的行为，如"播放"、"暂停"、"下载"等等。该项必填，不填、填"-"的事件会被抛弃。 |
+| opt_label | 事件的一些额外信息，通常可以是歌曲的名称、软件的名称、链接的名称等等。该项选填，不填、填"-"代表此项为空。 |
+| opt_value | 事件的一些数值信息，比如权重、时长、价格等等，在报表中可以看到其平均值等数据。该项可选。 |
+
+## LICENSE
+
+MIT

--- a/packages/@umijs/analytics/README.md
+++ b/packages/@umijs/analytics/README.md
@@ -12,7 +12,6 @@ export default {
     ['@umijs/analytics', {
       ga:'google analytics code',
       baidu: '5a66cxxxxxxxxxx9e13',
-      judge: ()=>true // true or false
     }],
   ],
 }

--- a/packages/@umijs/analytics/example/.umirc.js
+++ b/packages/@umijs/analytics/example/.umirc.js
@@ -1,0 +1,10 @@
+import { join } from 'path';
+
+export default {
+  plugins: [
+    [join(__dirname, '..', require('../package').main || 'index.js'),{
+      code: '5a66c03cb0ae986f876184554f2b9e13',
+      judge: ()=>true // true or false
+    }],
+  ],
+}

--- a/packages/@umijs/analytics/example/pages/index.css
+++ b/packages/@umijs/analytics/example/pages/index.css
@@ -1,0 +1,4 @@
+
+.normal {
+  background: #79F2AA;
+}

--- a/packages/@umijs/analytics/example/pages/index.js
+++ b/packages/@umijs/analytics/example/pages/index.js
@@ -1,0 +1,14 @@
+import styles from './index.css';
+
+export default function() {
+  const onClick = ()=>{
+    console.log('click text')
+    // _hmt.push(['_trackEvent', category, action, opt_label, opt_value]);
+    window._hmt.push(['_trackEvent', 'test', 'click', 'plugindemo', 'true']);
+  }
+  return (
+    <div className={styles.normal}>
+      <h1 onClick={onClick}>Page index</h1>
+    </div>
+  );
+}

--- a/packages/@umijs/analytics/package.json
+++ b/packages/@umijs/analytics/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@umijs/analytics",
+  "version": "1.0.0",
+  "description": "analytics for baidu tongji and google analytics",
+  "authors": {
+    "name": "xiaohuoni",
+    "email": "448627663@qq.com"
+  },
+  "repository": "https://github.com/umijs/plugins",
+  "peerDependencies": {
+    "umi": "2.x"
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "license": "MIT"
+}

--- a/packages/@umijs/analytics/package.json
+++ b/packages/@umijs/analytics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@umijs/analytics",
+  "name": "@umijs/plugin-analytics",
   "version": "1.0.0",
   "description": "analytics for baidu tongji and google analytics",
   "authors": {

--- a/packages/@umijs/analytics/src/index.ts
+++ b/packages/@umijs/analytics/src/index.ts
@@ -3,14 +3,14 @@
 
 export default function (api, opts) {
   const { baidu, ga, judge } = opts;
-  api.log.success("insert analytics");
+  api.log.success('insert analytics');
 
   const baiduTpl = function (code) {
     return `
     (function() {
-      var hm = document.createElement("script");
-      hm.src = "https://hm.baidu.com/hm.js?${code}";
-      var s = document.getElementsByTagName("script")[0];
+      var hm = document.createElement('script');
+      hm.src = 'https://hm.baidu.com/hm.js?${code}';
+      var s = document.getElementsByTagName('script')[0];
       s.parentNode.insertBefore(hm, s);
     })();
   `;
@@ -40,11 +40,11 @@ export default function (api, opts) {
 
   if (baidu) {
     api.addHTMLHeadScript({
-      content: 'var _hmt = _hmt || [];'
+      content: 'var _hmt = _hmt || [];',
     });
   }
 
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.NODE_ENV === 'production') {
     if (baidu) {
       api.addHTMLHeadScript({
         content: baiduTpl(baidu)

--- a/packages/@umijs/analytics/src/index.ts
+++ b/packages/@umijs/analytics/src/index.ts
@@ -5,10 +5,6 @@ export default function (api, opts) {
   const { baidu, ga, judge } = opts;
   api.log.success("insert analytics");
 
-  if (judge && !judge()) {
-    return false;
-  }
-
   const baiduTpl = function (code) {
     return `
     (function() {

--- a/packages/@umijs/analytics/src/index.ts
+++ b/packages/@umijs/analytics/src/index.ts
@@ -1,11 +1,11 @@
 // ref:
 // - https://umijs.org/plugin/develop.html
 
-export default function (api, opts) {
+export default function(api, opts) {
   const { baidu, ga, judge } = opts;
   api.log.success('insert analytics');
 
-  const baiduTpl = function (code) {
+  const baiduTpl = function(code) {
     return `
     (function() {
       var hm = document.createElement('script');
@@ -16,7 +16,7 @@ export default function (api, opts) {
   `;
   };
 
-  const gaTpl = function (code) {
+  const gaTpl = function(code) {
     return `
     (function(){
       if (!location.port) {
@@ -47,14 +47,13 @@ export default function (api, opts) {
   if (process.env.NODE_ENV === 'production') {
     if (baidu) {
       api.addHTMLHeadScript({
-        content: baiduTpl(baidu)
+        content: baiduTpl(baidu),
       });
     }
     if (ga) {
       api.addHTMLScript({
-        content: gaTpl(ga)
+        content: gaTpl(ga),
       });
     }
   }
-
-};
+}

--- a/packages/@umijs/analytics/src/index.ts
+++ b/packages/@umijs/analytics/src/index.ts
@@ -1,0 +1,64 @@
+// ref:
+// - https://umijs.org/plugin/develop.html
+
+export default function (api, opts) {
+  const { baidu, ga, judge } = opts;
+  api.log.success("insert analytics");
+
+  if (judge && !judge()) {
+    return false;
+  }
+
+  const baiduTpl = function (code) {
+    return `
+    (function() {
+      var hm = document.createElement("script");
+      hm.src = "https://hm.baidu.com/hm.js?${code}";
+      var s = document.getElementsByTagName("script")[0];
+      s.parentNode.insertBefore(hm, s);
+    })();
+  `;
+  };
+
+  const gaTpl = function (code) {
+    return `
+    (function(){
+      if (!location.port) {
+        (function (i, s, o, g, r, a, m) {
+          i['GoogleAnalyticsObject'] = r;
+          i[r] = i[r] || function () {
+              (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date();
+          a = s.createElement(o),
+            m = s.getElementsByTagName(o)[0];
+          a.async = 1;
+          a.src = g;
+          m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+        ga('create', '${code}', 'auto');
+        ga('send', 'pageview');
+      }
+    })();
+  `;
+  };
+
+  if (baidu) {
+    api.addHTMLHeadScript({
+      content: 'var _hmt = _hmt || [];'
+    });
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    if (baidu) {
+      api.addHTMLHeadScript({
+        content: baiduTpl(baidu)
+      });
+    }
+    if (ga) {
+      api.addHTMLScript({
+        content: gaTpl(ga)
+      });
+    }
+  }
+
+};


### PR DESCRIPTION
analytics for baidu tongji and google analytics

# @umijs/analytics

analytics for baidu tongji and google analytics

## Usage

Configure in `.umirc.js`,

```js
export default {
  plugins: [
    ['@umijs/analytics', {
      ga:'google analytics code',
      baidu: '5a66cxxxxxxxxxx9e13',
      judge: ()=>true // true or false
    }],
  ],
}
```

## Code

e.g `hm.src = "https://hm.baidu.com/hm.js?5a66c03cxxxxxx554f2b9e13";`
baidu is `5a66c03cxxxxxx554f2b9e13`

## 百度事件跟踪

> 在JS中调用事件跟踪代码。
> `window._hmt.push(['_trackEvent', category, action, opt_label, opt_value]);`
