### PR TITLE
feat: plugin-routes

### DIFF
--- a/packages/plugin-routes/README.md
+++ b/packages/plugin-routes/README.md
@@ -1,0 +1,61 @@
+# @umijs/plugin-routes
+
+routes modification plugin for umi.
+
+## Usage
+
+Install via yarn or npm.
+
+```bash
+$ yarn add @umijs/plugin-routes
+```
+
+Configure it in the `.umirc.js`.
+
+```js
+export default {
+   plugins: ['@umijs/plugin-routes'],
+   routesExtend: {
+     exclude: [],
+     update:(routes) => {
+        return routes；
+     }
+   }
+}
+```
+
+## routesExtend
+
+### routesExtend.exclude
+
+type: `Array(RegExp|Function)`
+
+e.g.
+
+```js
+{
+  exclude: [
+    // exclude all the `models` directory
+    /models\//,
+    // exclude ./pages/a.js
+    (route) { return route.component === './pages/a.js' },
+  ],
+}
+```
+
+### routesExtend.update
+
+type: `Function`
+
+e.g.
+
+```
+{
+  update(routes) {
+    return [
+      { path: '/foo', component: './bar.js' },
+      ...routes,
+    ];
+  }
+}
+```

--- a/packages/plugin-routes/package.json
+++ b/packages/plugin-routes/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@umijs/plugin-routes",
+  "version": "0.0.1",
+  "description": "@umijs/plugin-routes",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/umijs/plugins"
+  },
+  "keywords": [
+    "umi"
+  ],
+  "authors": [
+    "chencheng <sorrycc@gmail.com> (https://github.com/sorrycc)",
+    "xiaohuoni <448627663@qq.com> (https://github.com/xiaohuoni)"
+  ],
+  "license": "MIT",
+  "bugs": "http://github.com/umijs/plugins/issues",
+  "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-routes#readme",
+  "peerDependencies": {
+    "umi": "3.x"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-routes/src/docs/README.md
+++ b/packages/plugin-routes/src/docs/README.md
@@ -1,0 +1,61 @@
+# @umijs/plugin-routes
+
+routes modification plugin for umi.
+
+## Usage
+
+Install via yarn or npm.
+
+```bash
+$ yarn add @umijs/plugin-routes
+```
+
+Configure it in the `.umirc.js`.
+
+```js
+export default {
+   plugins: ['@umijs/plugin-routes'],
+   routesExtend: {
+     exclude: [],
+     update:(routes) => {
+        return routes；
+     }
+   }
+}
+```
+
+## routesExtend
+
+### routesExtend.exclude
+
+type: `Array(RegExp|Function)`
+
+e.g.
+
+```js
+{
+  exclude: [
+    // exclude all the `models` directory
+    /models\//,
+    // exclude ./pages/a.js
+    (route) { return route.component === './pages/a.js' },
+  ],
+}
+```
+
+### routesExtend.update
+
+type: `Function`
+
+e.g.
+
+```
+{
+  update(routes) {
+    return [
+      { path: '/foo', component: './bar.js' },
+      ...routes,
+    ];
+  }
+}
+```

--- a/packages/plugin-routes/src/exclude.test.ts
+++ b/packages/plugin-routes/src/exclude.test.ts
@@ -1,0 +1,47 @@
+import exclude from './exclude';
+
+describe('umi-plugin-routes:exclude', () => {
+  it('function', () => {
+    expect(
+      exclude(
+        [{ foo: 1 }, { bar: 1 }],
+        [
+          route => {
+            return 'foo' in route;
+          },
+        ],
+      ),
+    ).toEqual([{ bar: 1 }]);
+  });
+
+  it('regexp', () => {
+    expect(
+      exclude(
+        [{ component: 'a' }, { component: 'b' }, { component: 'c' }],
+        [/a|b/],
+      ),
+    ).toEqual([{ component: 'c' }]);
+  });
+
+  it('regexp (ignore arrow function)', () => {
+    expect(
+      exclude(
+        [{ component: '() => a' }, { component: 'b' }, { component: 'c' }],
+        [/a|b/],
+      ),
+    ).toEqual([{ component: '() => a' }, { component: 'c' }]);
+  });
+
+  it('support nested routes', () => {
+    expect(
+      exclude(
+        [{ foo: 1 }, { bar: 1, routes: [{ foo: 1 }, { bar: 1 }] }],
+        [
+          route => {
+            return 'foo' in route;
+          },
+        ],
+      ),
+    ).toEqual([{ bar: 1, routes: [{ bar: 1 }] }]);
+  });
+});

--- a/packages/plugin-routes/src/exclude.ts
+++ b/packages/plugin-routes/src/exclude.ts
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import { IRoute } from 'umi';
+type IExclude = Function | RegExp;
+
+export default function(routes: IRoute[], excludes: IExclude[]) {
+  function exclude(routes: IRoute[]) {
+    return routes.filter((route: IRoute) => {
+      for (const exclude of excludes) {
+        assert(
+          typeof exclude === 'function' || exclude instanceof RegExp,
+          `exclude should be function or RegExp`,
+        );
+
+        if (typeof exclude === 'function' && exclude(route)) {
+          return false;
+        }
+        if (
+          route.component &&
+          !route.component.startsWith('() =>') &&
+          exclude instanceof RegExp &&
+          exclude.test(route.component)
+        ) {
+          return false;
+        }
+      }
+      if (route.routes) {
+        route.routes = exclude(route.routes);
+      }
+      return true;
+    });
+  }
+
+  return exclude(routes);
+}

--- a/packages/plugin-routes/src/fixtures/exclude/.umirc.ts
+++ b/packages/plugin-routes/src/fixtures/exclude/.umirc.ts
@@ -1,0 +1,13 @@
+
+export default {
+  routesExtend:{
+    exclude: [
+      /model\.(j|t)sx?$/,
+      /\.test\.(j|t)sx?$/,
+      /service\.(j|t)sx?$/,
+      /models\//,
+      /components\//,
+      /services\//
+    ]
+  }
+}

--- a/packages/plugin-routes/src/fixtures/exclude/pages/index.less
+++ b/packages/plugin-routes/src/fixtures/exclude/pages/index.less
@@ -1,0 +1,7 @@
+
+.normal {
+}
+
+.title {
+  background: rgb(196, 242, 121);
+}

--- a/packages/plugin-routes/src/fixtures/exclude/pages/index.tsx
+++ b/packages/plugin-routes/src/fixtures/exclude/pages/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from './index.less';
+import { connect } from 'dva';
+
+export default connect(state => ({
+  foo: state.foo,
+}))((props) => {
+  return (
+    <div>
+      <h1 className={styles.title}>Page index { props.foo.desc } { props.foo.count }</h1>
+    </div>
+  );
+})

--- a/packages/plugin-routes/src/fixtures/exclude/pages/model.ts
+++ b/packages/plugin-routes/src/fixtures/exclude/pages/model.ts
@@ -1,0 +1,7 @@
+
+export default {
+  state: {
+    desc: 'foo',
+    count: 0,
+  },
+}

--- a/packages/plugin-routes/src/fixtures/update/.umirc.ts
+++ b/packages/plugin-routes/src/fixtures/update/.umirc.ts
@@ -1,0 +1,15 @@
+
+import { IRoute } from 'umi';
+
+export default {
+  routesExtend: {
+    update(routes: IRoute[]) {
+      return routes.filter((route: IRoute) => {
+        if (/model\.(j|t)sx?$/.test(route.component)) {
+          return false;
+        }
+        return true;
+      });
+    }
+  }
+}

--- a/packages/plugin-routes/src/fixtures/update/pages/index.less
+++ b/packages/plugin-routes/src/fixtures/update/pages/index.less
@@ -1,0 +1,7 @@
+
+.normal {
+}
+
+.title {
+  background: rgb(196, 242, 121);
+}

--- a/packages/plugin-routes/src/fixtures/update/pages/index.tsx
+++ b/packages/plugin-routes/src/fixtures/update/pages/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from './index.less';
+import { connect } from 'dva';
+
+export default connect(state => ({
+  foo: state.foo,
+}))((props) => {
+  return (
+    <div>
+      <h1 className={styles.title}>Page index { props.foo.desc } { props.foo.count }</h1>
+    </div>
+  );
+})

--- a/packages/plugin-routes/src/fixtures/update/pages/model.ts
+++ b/packages/plugin-routes/src/fixtures/update/pages/model.ts
@@ -1,0 +1,7 @@
+
+export default {
+  state: {
+    desc: 'foo',
+    count: 0,
+  },
+}

--- a/packages/plugin-routes/src/index.test.ts
+++ b/packages/plugin-routes/src/index.test.ts
@@ -1,0 +1,47 @@
+import { join } from 'path';
+import { Service } from 'umi';
+import { Route } from '@umijs/core';
+
+const fixtures = join(__dirname, 'fixtures');
+
+test('exclude', async () => {
+  const cwd = join(fixtures, 'exclude');
+  const service = new Service({
+    cwd,
+    plugins: [require.resolve('./')],
+  });
+  await service.init();
+  const route = new Route();
+  const routes = await service.applyPlugins({
+    key: 'modifyRoutes',
+    type: service.ApplyPluginsType.modify,
+    initialValue: await route.getRoutes({
+      config: {},
+      root: join(cwd, 'pages'),
+    }),
+  });
+  expect(routes).toEqual([
+    { component: '@/pages/index.tsx', exact: true, path: '/' },
+  ]);
+});
+
+test('update', async () => {
+  const cwd = join(fixtures, 'update');
+  const service = new Service({
+    cwd,
+    plugins: [require.resolve('./')],
+  });
+  await service.init();
+  const route = new Route();
+  const routes = await service.applyPlugins({
+    key: 'modifyRoutes',
+    type: service.ApplyPluginsType.modify,
+    initialValue: await route.getRoutes({
+      config: {},
+      root: join(cwd, 'pages'),
+    }),
+  });
+  expect(routes).toEqual([
+    { component: '@/pages/index.tsx', exact: true, path: '/' },
+  ]);
+});

--- a/packages/plugin-routes/src/index.ts
+++ b/packages/plugin-routes/src/index.ts
@@ -1,0 +1,47 @@
+import { IApi } from 'umi';
+import assert from 'assert';
+import exclude from './exclude';
+
+function optsToArray(item: any) {
+  if (!item) return [];
+  if (Array.isArray(item)) {
+    return item;
+  } else {
+    return [item];
+  }
+}
+
+interface IOpts {
+  exclude: string[] | string;
+  update: Function;
+}
+
+export default function(api: IApi) {
+  // disable if routes if configured
+  if (api.userConfig.routes) return;
+
+  const routesExtend = api.userConfig.routesExtend;
+
+  api.describe({
+    key: 'routesExtend',
+    config: {
+      schema(joi) {
+        return joi.object();
+      },
+    },
+  });
+
+  api.modifyRoutes(routes => {
+    routes = exclude(routes, optsToArray(routesExtend.exclude));
+
+    if (routesExtend.update) {
+      assert(
+        typeof routesExtend.update === 'function',
+        `opts.update should be function, but got ${routesExtend.update}`,
+      );
+      routes = routesExtend.update(routes);
+    }
+
+    return routes;
+  });
+}

--- a/packages/plugin-routes/src/index.ts
+++ b/packages/plugin-routes/src/index.ts
@@ -20,8 +20,6 @@ export default function(api: IApi) {
   // disable if routes if configured
   if (api.userConfig.routes) return;
 
-  const routesExtend = api.userConfig.routesExtend;
-
   api.describe({
     key: 'routesExtend',
     config: {
@@ -32,6 +30,7 @@ export default function(api: IApi) {
   });
 
   api.modifyRoutes(routes => {
+    const { routesExtend } = api.config;
     routes = exclude(routes, optsToArray(routesExtend.exclude));
 
     if (routesExtend.update) {

--- a/packages/plugin-routes/src/index.ts
+++ b/packages/plugin-routes/src/index.ts
@@ -31,6 +31,7 @@ export default function(api: IApi) {
 
   api.modifyRoutes(routes => {
     const { routesExtend } = api.config;
+    if (!routesExtend) return routes;
     routes = exclude(routes, optsToArray(routesExtend.exclude));
 
     if (routesExtend.update) {


### PR DESCRIPTION
umi-plugin-routes 迁移 umi@3
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

由于 `umi-plugin-react` 废弃了，所以 `umi-plugin-react` 的 `routes` 配置无用了。
由于已经有一个 `routes` 了，所以加了一个配置 `routesExtend`。

```js
export default {
   plugins: ['@umijs/plugin-routes'],
   routesExtend: {
     exclude: [],
     update:(routes) => {
        return routes；
     }
   }
}
```