### PR TITLE
 fix(locale): remove unuse IntlProvider

### DIFF
--- a/packages/plugin-locale/src/locale.tpl
+++ b/packages/plugin-locale/src/locale.tpl
@@ -1,6 +1,6 @@
 import React from 'react';
 import EventEmitter from 'events';
-import { IntlProvider, RawIntlProvider, getLocale, setIntl, getIntl } from './localeExports';
+import { RawIntlProvider, getLocale, setIntl, getIntl } from './localeExports';
 
 export const event = new EventEmitter();
 event.setMaxListeners(5);
@@ -25,9 +25,5 @@ export const _LocaleContainer = props => {
     };
   }, []);
 
-  return (
-    <IntlProvider>
-      <RawIntlProvider value={intl}>{props.children}</RawIntlProvider>
-    </IntlProvider>
-  );
+  return <RawIntlProvider value={intl}>{props.children}</RawIntlProvider>;
 };


### PR DESCRIPTION
看了一下源码 

[RawIntlProvider ](https://github.com/formatjs/react-intl/blob/b207d805a9e5609983ac1b2ca8f9708030e12337/src/components/injectIntl.tsx#L17)是一个 React.createContext 的 Provider 对象

[IntlProvider  ](https://github.com/formatjs/react-intl/blob/b207d805a9e5609983ac1b2ca8f9708030e12337/src/components/provider.tsx)是一个包装了  RawIntlProvider  的组件，根据生命周期来进行更新

对于我们而言使用 RawIntlProvider  更加合理，问题应该是在别地方