### PR TITLE
feat: support antd dark 

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -1,6 +1,10 @@
 import { dirname } from 'path';
 import { IApi } from 'umi';
 
+interface IAntdOpts {
+  dark?: boolean;
+}
+
 export default (api: IApi) => {
   api.describe({
     config: {
@@ -19,6 +23,24 @@ export default (api: IApi) => {
       ]),
     };
   });
+
+  const opts: IAntdOpts = api.userConfig.antd || {};
+
+  if (opts?.dark) {
+    // support dark mode, user use antd 4 by default
+    const darkThemeVars = require('antd/dist/dark-theme');
+    api.modifyDefaultConfig(config => {
+      const draftConfig = Object.assign({}, config);
+      draftConfig.theme = {
+        hack_less_umi_plugin: `true;@import "${require.resolve(
+          'antd/lib/style/color/colorPalette.less',
+        )}";`,
+        ...darkThemeVars,
+        ...(draftConfig.theme || {}),
+      };
+      return draftConfig;
+    });
+  }
 
   api.addProjectFirstLibraries(() => [
     {

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -32,15 +32,14 @@ export default (api: IApi) => {
     // support dark mode, user use antd 4 by default
     const darkThemeVars = require('antd/dist/dark-theme');
     api.modifyDefaultConfig(config => {
-      const draftConfig = Object.assign({}, config);
-      draftConfig.theme = {
+      config.theme = {
         hack_less_umi_plugin: `true;@import "${require.resolve(
           'antd/lib/style/color/colorPalette.less',
         )}";`,
         ...darkThemeVars,
-        ...(draftConfig.theme || {}),
+        ...(config.theme || {}),
       };
-      return draftConfig;
+      return config;
     });
   }
 

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -9,7 +9,9 @@ export default (api: IApi) => {
   api.describe({
     config: {
       schema(joi) {
-        return joi.object();
+        return joi.object({
+          dark: joi.boolean(),
+        });
       },
     },
   });

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -37,7 +37,7 @@ export default (api: IApi) => {
           'antd/lib/style/color/colorPalette.less',
         )}";`,
         ...darkThemeVars,
-        ...(config.theme || {}),
+        ...config.theme,
       };
       return config;
     });


### PR DESCRIPTION
支持一键开启暗色主题：

```js
export default {
  antd: {
    dark: true
  }
}
```

antd doc: https://github.com/ant-design/ant-design/pull/21668