### PR TITLE
feat: locale polyfill and runtime config

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "lint-staged": "^10.0.8",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
-    "qs": "^6.9.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.9.0",
     "umi": "^3.0.0-beta.32",
+    "query-string": "^6.11.0",
     "yorkie": "^2.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint-staged": "^10.0.8",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
+    "qs": "^6.9.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.9.0",

--- a/packages/plugin-locale/docs/README.md
+++ b/packages/plugin-locale/docs/README.md
@@ -191,7 +191,7 @@ export const locale = {
 
 - lang: 需要切换的语言
 - realReload: 是否需要刷新页面，这个是由页面调用 `setLocale(lang, true)` 透传。
-- updater：是否需要强制更新当前组件国际化状态。
+- updater：是否触发组件 rerender 重渲染。
 
 ```js
 // src/app.js

--- a/packages/plugin-locale/docs/README.md
+++ b/packages/plugin-locale/docs/README.md
@@ -164,6 +164,45 @@ setLocale('zh-TW', true);
 setLocale('zh-TW', false);
 ```
 
+### 运行时配置
+
+支持运行时对国际化做一些扩展与定制，例如自定义语言识别等。
+
+#### getLocale
+
+自定义语言获取逻辑，比如识别链接 `?locale=${lang}` 当做当前页面的语言。
+
+```js
+// src/app.js
+import qs from 'qs';
+
+export const locale = {
+  getLocale() {
+    const { search } = window.location;
+    const { locale = 'zh-CN' } = qs.parse(search, { ignoreQueryPrefix: true });
+    return locale;
+  },
+};
+```
+
+#### setLocale
+
+自定义语言切换逻辑。其中有三个参数：
+
+- lang: 需要切换的语言
+- realReload: 是否需要刷新页面，这个是由页面调用 `setLocale(lang, true)` 透传。
+- updater：是否需要强制更新当前组件国际化状态。
+
+```js
+// src/app.js
+export const locale = {
+  setLocale({ lang, realReload, updater }) {
+    history.push(`/?locale=${lang}`);
+    updater();
+  },
+};
+```
+
 ## FAQ
 
 ### 为什么不要使用 formatMessage 这个语法糖？

--- a/packages/plugin-locale/fixtures/runtime/.umirc.ts
+++ b/packages/plugin-locale/fixtures/runtime/.umirc.ts
@@ -1,0 +1,17 @@
+
+export default {
+  history: {
+    type: 'memory',
+    options: {
+      initialEntries: ['/'],
+    },
+  },
+  locale: {
+    antd: true,
+    title: true,
+  },
+  mountElementId: '',
+  routes: [
+    { path: '/', component: 'index' },
+  ],
+}

--- a/packages/plugin-locale/fixtures/runtime/src/app.js
+++ b/packages/plugin-locale/fixtures/runtime/src/app.js
@@ -1,6 +1,6 @@
 
 import { history } from './.umi-test/core/history';
-import queryString from 'queryString';
+import queryString from 'query-string';
 
 export const locale = {
   getLocale() {

--- a/packages/plugin-locale/fixtures/runtime/src/app.js
+++ b/packages/plugin-locale/fixtures/runtime/src/app.js
@@ -1,11 +1,11 @@
 
 import { history } from './.umi-test/core/history';
-import qs from 'qs';
+import queryString from 'queryString';
 
 export const locale = {
   getLocale() {
     const { search } = window.location;
-    const { locale = 'sk' } = qs.parse(search, { ignoreQueryPrefix: true });
+    const { locale = 'sk' } = queryString.parse(search);
     return locale;
   },
   setLocale({ lang, realReload, updater }) {

--- a/packages/plugin-locale/fixtures/runtime/src/app.js
+++ b/packages/plugin-locale/fixtures/runtime/src/app.js
@@ -1,0 +1,15 @@
+
+import { history } from './.umi-test/core/history';
+import qs from 'qs';
+
+export const locale = {
+  getLocale() {
+    const { search } = window.location;
+    const { locale = 'sk' } = qs.parse(search, { ignoreQueryPrefix: true });
+    return locale;
+  },
+  setLocale({ lang, realReload, updater }) {
+    history.push(`/?locale=${lang}`);
+    updater();
+  }
+}

--- a/packages/plugin-locale/fixtures/runtime/src/locales/en-US.js
+++ b/packages/plugin-locale/fixtures/runtime/src/locales/en-US.js
@@ -1,0 +1,6 @@
+export default {
+  title: 'Title',
+  'about.title': 'About Title',
+  'default.title': 'Default Title',
+  name: 'Hello {name}',
+};

--- a/packages/plugin-locale/fixtures/runtime/src/locales/sk.js
+++ b/packages/plugin-locale/fixtures/runtime/src/locales/sk.js
@@ -1,0 +1,6 @@
+export default {
+  title: 'skTitle',
+  'about.title': 'sk about Title',
+  'default.title': 'sk default Title',
+  name: 'sk {name}',
+};

--- a/packages/plugin-locale/fixtures/runtime/src/locales/zh-CN.js
+++ b/packages/plugin-locale/fixtures/runtime/src/locales/zh-CN.js
@@ -1,0 +1,6 @@
+export default {
+  title: '标题',
+  'about.title': '关于标题',
+  'default.title': '默认标题',
+  name: '你好 {name}',
+};

--- a/packages/plugin-locale/fixtures/runtime/src/pages/index.jsx
+++ b/packages/plugin-locale/fixtures/runtime/src/pages/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'umi';
+import { DatePicker } from 'antd';
+import moment from 'moment';
+import { useIntl, getLocale, getAllLocales, setLocale } from '../.umi-test/plugin-locale/localeExports';
+
+export default function(props) {
+  const intl = useIntl();
+  const list = getAllLocales();
+  const locale = getLocale();
+
+  return (
+    <div>
+      <h1>Current language:{locale}</h1>
+      <h2>标题: <p id="title">{props.route.title}</p></h2>
+      <DatePicker />
+      <p id="moment">{moment().set({
+              year: 2020,
+              month: 2,
+              date: 21,
+            })
+            .format('LL')}</p>
+      {list.map(locale => (
+        <Link key={locale} to={`/?locale=${locale}`}>
+          {locale}
+        </Link>
+      ))}
+      <p data-testid="display" type="primary">
+        {intl.formatMessage(
+          {
+            id: 'name',
+          },
+          {
+            name: 'Traveler',
+          },
+        )}
+      </p>
+    </div>
+  );
+}

--- a/packages/plugin-locale/src/index.test.ts
+++ b/packages/plugin-locale/src/index.test.ts
@@ -146,3 +146,30 @@ test('singular', async () => {
   );
   expect(getByTestId('display')?.textContent).toEqual('sk Traveler');
 });
+
+test('runtime', async () => {
+  const cwd = join(fixtures, 'runtime');
+  const service = new Service({
+    cwd,
+    plugins: [require.resolve('./')],
+  });
+  await service.run({
+    name: 'g',
+    args: {
+      _: ['g', 'tmp'],
+    },
+  });
+
+  const reactNode = require(join(cwd, 'src', '.umi-test', 'umi.ts')).default;
+  const { container, rerender, getByTestId, getByText } = render(reactNode);
+  expect(container.querySelector('h1')?.textContent).toEqual(
+    'Current language:sk',
+  );
+  expect(
+    container.querySelector('.ant-picker-input > input')?.placeholder,
+  ).toEqual('Vybrať dátum');
+  expect(container.querySelector('#moment')?.textContent).toEqual(
+    '21. marec 2020',
+  );
+  expect(getByTestId('display')?.textContent).toEqual('sk Traveler');
+});

--- a/packages/plugin-locale/src/index.ts
+++ b/packages/plugin-locale/src/index.ts
@@ -39,6 +39,13 @@ export default (api: IApi) => {
     enableBy: api.EnableBy.config,
   });
 
+  // polyfill
+  if (isNeedPolyfill(api.userConfig?.targets || {})) {
+    api.addEntryImportsAhead(() => ({
+      source: require.resolve('intl'),
+    }));
+  }
+
   const getList = (): IGetLocaleFileListResult[] => {
     return getLocaleList({
       localeFolder: api.config?.singular ? 'locale' : 'locales',
@@ -47,6 +54,9 @@ export default (api: IApi) => {
       absPagesPath: paths.absPagesPath,
     });
   };
+
+  // add runtime locale
+  api.addRuntimePluginKey(() => 'locale');
 
   // 生成临时文件
   api.onGenerateFiles(() => {

--- a/packages/plugin-locale/src/index.ts
+++ b/packages/plugin-locale/src/index.ts
@@ -26,6 +26,10 @@ export default (api: IApi) => {
   api.describe({
     key: 'locale',
     config: {
+      default: {
+        baseNavigator: true,
+        baseSeparator: '-',
+      },
       schema(joi) {
         return joi.object({
           default: joi.string(),
@@ -49,7 +53,7 @@ export default (api: IApi) => {
   const getList = (): IGetLocaleFileListResult[] => {
     return getLocaleList({
       localeFolder: api.config?.singular ? 'locale' : 'locales',
-      separator: api.config.locale?.baseSeparator || '-',
+      separator: api.config.locale?.baseSeparator,
       absSrcPath: paths.absSrcPath,
       absPagesPath: paths.absPagesPath,
     });
@@ -64,8 +68,8 @@ export default (api: IApi) => {
       join(__dirname, 'templates', 'locale.tpl'),
       'utf-8',
     );
-    const { baseSeparator = '-', baseNavigator = true, antd, title } = api
-      .config.locale as ILocaleConfig;
+    const { baseSeparator, baseNavigator, antd, title } = api.config
+      .locale as ILocaleConfig;
     const defaultLocale = api.config.locale?.default || `zh${baseSeparator}CN`;
 
     const localeList = getList();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3941,7 +3941,7 @@ antd-mobile@^2.3.1:
     rmc-tabs "~1.2.0"
     rmc-tooltip "~1.0.0"
 
-antd@^4.0.0-beta.0, antd@^4.0.0-rc.1, antd@^4.0.0-rc.4:
+antd@^4.0.0, antd@^4.0.0-beta.0, antd@^4.0.0-rc.4:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/antd/-/antd-4.0.0.tgz#1566ee4a4c9ff5deb446cc3ce7604d4495fd2d38"
   integrity sha512-sfaxNqqtaGg+5JWucSPM0Nr3eBh5gUBlmsH5RqdtpcP5qTM2NOxcmhx3I8KlSs5O39jAZ6nRVmjubjpw3GS5oQ==
@@ -6034,7 +6034,7 @@ debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -6174,11 +6174,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -7949,7 +7944,7 @@ hyphenate-style-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -9174,11 +9169,6 @@ jest@^25.1.0:
     import-local "^3.0.2"
     jest-cli "^25.1.0"
 
-js-cookie@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
-
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -9690,11 +9680,6 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
-
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -10522,15 +10507,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
-  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -10641,22 +10617,6 @@ node-notifier@^6.0.0:
     semver "^6.3.0"
     shellwords "^0.1.1"
     which "^1.3.1"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-releases@^1.1.50:
   version "1.1.50"
@@ -10773,7 +10733,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -10820,7 +10780,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -12975,7 +12935,7 @@ rc-virtual-list@^1.0.0, rc-virtual-list@~1.0.0:
     classnames "^2.2.6"
     rc-util "^4.8.0"
 
-rc@^1.2.7, rc@^1.2.8:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -13673,7 +13633,7 @@ rimraf@3.0.2, rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -14031,7 +13991,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -14961,7 +14921,7 @@ tapable@2.0.0-beta.9, tapable@^2.0.0-beta.8:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.0.0-beta.9.tgz#638496fb27b53e69c21a0e6a4435afbe805845cb"
   integrity sha512-+VBUuZXh+WIHnKOeo+A27SB/1sHTVWozcKweDIAhB/XOGnr8cy6ULZjU+qpGxO/G4xEyWCCaWTX/HPEkGg3Xrg==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
### 运行时配置

支持运行时对国际化做一些扩展与定制，例如自定义语言识别等。

#### getLocale

自定义语言获取逻辑，比如识别链接 `?locale=${lang}` 当做当前页面的语言。

```js
// src/app.js
import qs from 'qs';

export const locale = {
  getLocale() {
    const { search } = window.location;
    const { locale = 'zh-CN' } = qs.parse(search, { ignoreQueryPrefix: true });
    return locale;
  },
}
```

#### setLocale

自定义语言切换逻辑。其中有三个参数：

- lang: 需要切换的语言
- realReload: 是否需要刷新页面，这个是由页面调用 `setLocale(lang, true)` 透传。
- updater：是否触发组件 rerender 重渲染。

```js
// src/app.js
export const locale = {
  setLocale({ lang, realReload, updater }) {
    history.push(`/?locale=${lang}`);
    updater();
  }
}
```