### PR TITLE
fix: 升级 antd4.0 后，路由 icon 配置不生效的问题

### DIFF
--- a/example/.umirc.ts
+++ b/example/.umirc.ts
@@ -7,10 +7,12 @@ export default defineConfig({
     {
       name: 'model 测试',
       path: '/plugin-model',
+      icon: 'home',
       component: './plugin-model',
     },
     {
       name: 'initial-state 测试',
+      icon: 'heart',
       path: '/plugin-initial-state',
       component: './plugin-initial-state',
     },

--- a/packages/preset-react/package.json
+++ b/packages/preset-react/package.json
@@ -37,6 +37,7 @@
     "@umijs/plugin-layout": "0.5.1",
     "@umijs/plugin-locale": "0.3.0",
     "@umijs/plugin-model": "2.1.2",
-    "@umijs/plugin-request": "2.2.1"
+    "@umijs/plugin-request": "2.2.1",
+    "umi-plugin-antd-icon-config": "^2.0.0-0"
   }
 }

--- a/packages/preset-react/src/index.ts
+++ b/packages/preset-react/src/index.ts
@@ -1,6 +1,7 @@
 export default () => {
   return {
     plugins: [
+      require.resolve('umi-plugin-antd-icon-config'),
       require.resolve('@umijs/plugin-access'),
       require.resolve('@umijs/plugin-analytics'),
       require.resolve('@umijs/plugin-antd'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,21 @@
   dependencies:
     tinycolor2 "^1.4.1"
 
-"@ant-design/icons-svg@^4.0.0-rc.0":
+"@ant-design/icons-svg@^4.0.0", "@ant-design/icons-svg@^4.0.0-rc.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.0.0.tgz#6683db0df97c0c6900bb28a280faf391522ec734"
   integrity sha512-Nai+cd3XUrv/z50gSk1FI08j6rENZ1e93rhKeLTBGwa5WrmHvhn2vowa5+voZW2qkXJn1btS6tdvTEDB90M0Pw==
+
+"@ant-design/icons@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.0.2.tgz#6fce64b3e207d99d1e258ff527674e22b9b2afc0"
+  integrity sha512-fs256mh5tQ0q+o2xNper5dThCZqmWRyQfstf+UrXhotAAv52K+6grh2tzdvsl60fk4GZPLReytwL5rJqATW3uA==
+  dependencies:
+    "@ant-design/colors" "^3.1.0"
+    "@ant-design/icons-svg" "^4.0.0"
+    classnames "^2.2.6"
+    insert-css "^2.0.0"
+    rc-util "^4.9.0"
 
 "@ant-design/icons@^4.0.0-alpha.11", "@ant-design/icons@^4.0.0-rc.0":
   version "4.0.0-rc.0"
@@ -15368,6 +15379,13 @@ umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+umi-plugin-antd-icon-config@^2.0.0-0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/umi-plugin-antd-icon-config/-/umi-plugin-antd-icon-config-2.0.0.tgz#321daf49f4d30f16b9239ce68c8f9673a29ca8d4"
+  integrity sha512-yp+aYpkBNLR53knRMrPi3UJDuIGvjhx9xA7jvZKRg8t5OH82oTmgGbGIbC9RfySEhAvt/37nYJdLDQaffn3Qww==
+  dependencies:
+    "@ant-design/icons" "^4.0.0"
 
 umi-request@^1.1.0, umi-request@^1.2.14, umi-request@^1.2.17:
   version "1.2.19"


### PR DESCRIPTION
关联的 pr: https://github.com/umijs/umi-plugin-antd-icon-config/pull/4