### PR TITLE
docs: update install bash

### DIFF
--- a/packages/plugin-qiankun/README.md
+++ b/packages/plugin-qiankun/README.md
@@ -9,11 +9,13 @@ See our website [@umijs/plugin-qiankun](https://umijs.org/plugins/plugin-qiankun
 Using npm:
 
 ```bash
-$ npm install --save-dev @umijs/plugin-qiankun
+$ npm install --save-dev @umijs/plugin-qiankun@2
 ```
 
 or using yarn:
 
 ```bash
-$ yarn add @umijs/plugin-qiankun --dev
+$ yarn add @umijs/plugin-qiankun@2 --dev
 ```
+
+> note: `@umijs/plugin-qiankun@1` is for `umi@2`


### PR DESCRIPTION
不指定 `@2` 或者 `@next` 会装错 qiankun 插件版本