### PR TITLE
export getRequestMethod

### DIFF
--- a/packages/plugin-request/src/request.ts
+++ b/packages/plugin-request/src/request.ts
@@ -242,4 +242,4 @@ const request: RequestMethodInUmi = (url: any, options: any) => {
   return requestMethod(url, options);
 };
 
-export { request, useRequest };
+export { request, useRequest, getRequestMethod };


### PR DESCRIPTION
如果不导出的话，就无法使用 umi-request 提供的例如拦截器等功能了。