### PR TITLE
fix: dva types bug

### DIFF
--- a/packages/plugin-dva/src/connect.tpl
+++ b/packages/plugin-dva/src/connect.tpl
@@ -39,6 +39,7 @@ export interface Loading {
   effects: { [key: string]: boolean | undefined };
   models: {
 {{{ dvaLoadingModels }}}
+    [key: string]: boolean | undefined;
   };
 }
 

--- a/packages/plugin-dva/src/index.ts
+++ b/packages/plugin-dva/src/index.ts
@@ -156,9 +156,9 @@ app.model({ namespace: '${basename(path, extname(path))}', ...(require('${path}'
             .join('\r\n'),
           dvaLoadingModels: models
             .map(path => {
+              if (basename(path, extname(path)) === 'model') return '';
               // prettier-ignore
-              return `    ${basename(path, extname(path))
-                } ?: boolean;`;
+              return `    "${basename(path, extname(path))}" ?: boolean;`;
             })
             .join('\r\n'),
         }),


### PR DESCRIPTION
Close: https://github.com/umijs/plugins/issues/89
## 问题1
文件名或者 namespace 里面带特殊字符的，这个通过加双引号可以解决。
> 带特殊字符的，dva 里面的绑定也很难取到值。不建议使用。

## 问题2
有 namespace 存在的时候应该先取 namespace

尝试了好久，都没办法动态给类型添加属性，比如 `require('${path}').default.namespace || "${basename(path, extname(path))}"`

也尝试了
```
const getType = (a?:boolean)=>a;

const load ={
    models:{
    }
}
load.models[ require('${path}').default.namespace || "${basename(path, extname(path))}" ] = getType();
type LoadType = typeof load；
interface Loading extends LoadType {}
```
这样都无法找到类型。

## 最终解法

给文件名当key的时候，加了双引号。

文件名为model的时候，做了过滤。

增加了 `[key: string]: boolean | undefined;`

最终效果，运行时类型都正确，编写代码的时候，只有文件名和 namespace 一致的情况，能有代码联想。

## Need Help

研究了三四个小时，毫无进展，不知道有什么写法能够动态添加类型定义，还望指导。
@chenshuai2144 @imhele 