### PR TITLE
feat: 🆕 Add compact theme config to plugin-antd

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -3,6 +3,7 @@ import { IApi } from 'umi';
 
 interface IAntdOpts {
   dark?: boolean;
+  compact?: boolean;
 }
 
 export default (api: IApi) => {
@@ -11,6 +12,7 @@ export default (api: IApi) => {
       schema(joi) {
         return joi.object({
           dark: joi.boolean(),
+          compact: joi.boolean(),
         });
       },
     },
@@ -28,17 +30,25 @@ export default (api: IApi) => {
 
   const opts: IAntdOpts = api.userConfig.antd || {};
 
-  if (opts?.dark) {
+  if (opts?.dark || opts?.compact) {
     // support dark mode, user use antd 4 by default
-    const darkThemeVars = require('antd/dist/dark-theme');
+    const darkTheme = opts?.dark ? require('antd/dist/dark-theme') : {};
+    const compactTheme = opts?.compact
+      ? require('antd/dist/compact-theme')
+      : {};
     api.modifyDefaultConfig(config => {
       config.theme = {
-        hack_less_umi_plugin: `true;@import "${require.resolve(
-          'antd/lib/style/color/colorPalette.less',
-        )}";`,
-        ...darkThemeVars,
+        ...darkTheme,
+        ...compactTheme,
         ...config.theme,
       };
+      if (opts?.dark) {
+        config.theme![
+          'hack_less_umi_plugin'
+        ] = `true;@import "${require.resolve(
+          'antd/lib/style/color/colorPalette.less',
+        )}";`;
+      }
       return config;
     });
   }


### PR DESCRIPTION
ant-design/ant-design#22068

Usage: https://github.com/ant-design/ant-design/blob/dad364c7f24a486ec54f38e741b5f1a81f9c105a/docs/react/customize-theme.en-US.md#use-dark-or-compact-theme