### PR TITLE
fix: prevent unexpected undefined value passed to subsequent process

### DIFF
--- a/packages/plugin-initial-state/src/utils/getModelContent.tsx
+++ b/packages/plugin-initial-state/src/utils/getModelContent.tsx
@@ -21,7 +21,7 @@ export default () => {
   const [ state, setState ] = useState(initState);
 
   const refresh = async() => {
-    setState(s => ({ ...s, loading: true, initialState: undefined, error: undefined }))
+    setState(s => ({ ...s, loading: true, error: undefined }))
     try {
       const asyncFunc = () => new Promise<ReturnType<typeof getInitialState>>(res => res(getInitialState()));
       const ret = await asyncFunc();


### PR DESCRIPTION
开发者自己调用`initial-state`的`refresh`方法时，`access`会收到中间状态，但这个是不合理的。`access.ts`中应该永远只拿到结果