### PR TITLE
[WIP] 使 plugin-layout 支持多Tabs

### DIFF
--- a/packages/plugin-layout/package.json
+++ b/packages/plugin-layout/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@umijs/plugin-layout",
-  "version": "0.6.1",
+  "name": "@alitajs/plugin-layout",
+  "version": "0.0.1",
   "description": "@umijs/plugin-layout",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/packages/plugin-layout/src/index.ts
+++ b/packages/plugin-layout/src/index.ts
@@ -50,10 +50,14 @@ export default (api: IApi) => {
 
     api.writeTmpFile({
       path: join(DIR_NAME, 'Layout.tsx'),
-      content: getLayoutContent(layoutOpts, currentLayoutComponentPath),
+      content: getLayoutContent(
+        layoutOpts,
+        currentLayoutComponentPath,
+        !!api.userConfig.tabsLayout,
+      ),
     });
 
-    // TODO: 修改 icon 的加载为按需
+    // TODO: 修改 icon 的加载为按
     // 用文件生成的方式，方便之后修改 icon 为按需
     api.writeTmpFile({
       path: join(DIR_NAME, 'runtime.tsx'),

--- a/packages/plugin-layout/src/layout/index.tsx
+++ b/packages/plugin-layout/src/layout/index.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo } from 'react';
-import { Link, useModel, history, useIntl, InitialState } from 'umi';
+import {
+  Link,
+  useModel,
+  history,
+  useIntl,
+  InitialState,
+  TabsLayout,
+} from 'umi';
 import pathToRegexp from 'path-to-regexp';
 import ProLayout from '@ant-design/pro-layout';
 import './style.less';
@@ -12,7 +19,7 @@ import { MenuItem } from '../types/interface.d';
 import logo from '../assets/logo.svg';
 
 const BasicLayout = (props: any) => {
-  const { children, userConfig, location } = props;
+  const { children, userConfig, location, hasTabsLayout } = props;
   const initialInfo = (useModel && useModel('@@initialState')) || {
     initialState: undefined,
     loading: false,
@@ -83,7 +90,10 @@ const BasicLayout = (props: any) => {
       {...layoutRender}
     >
       <ErrorBoundary>
-        {WithExceptionOpChildren(children, currentPathConfig)}
+        {WithExceptionOpChildren(
+          hasTabsLayout ? <TabsLayout {...props} /> : children,
+          currentPathConfig,
+        )}
       </ErrorBoundary>
     </ProLayout>
   );

--- a/packages/plugin-layout/src/utils/getLayoutContent.tsx
+++ b/packages/plugin-layout/src/utils/getLayoutContent.tsx
@@ -3,6 +3,7 @@ import { LayoutConfig } from '../types/interface.d';
 export default (
   userConfig: LayoutConfig,
   path: string,
+  hasTabsLayout: boolean,
 ) => `import React from 'react';
 import { ApplyPluginsType } from 'umi';
 import { plugin } from '../core/umiExports';
@@ -19,6 +20,7 @@ export default (props) => {
   };
   return React.createElement(require('${path}').default, {
     userConfig,
+    hasTabsLayout: ${hasTabsLayout},
     ...props
   })
 }


### PR DESCRIPTION
> 临时给朋友使用的库，不要合并。

安装 `@alitajs/tabs-layout`，`@alitajs/plugin-layout`，然后添加配置
```ts
export default {
  plugins:['@alitajs/tabs-layout','@alitajs/plugin-layout'],
  tabsLayout: [/./], // 这里表示所有的页面
  // 其他 @umijs/plugin-layout 的配置和用法。
};
```