### PR TITLE
fix: compact mode throw error

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -38,17 +38,13 @@ export default (api: IApi) => {
       : {};
     api.modifyDefaultConfig(config => {
       config.theme = {
+        'hack_less_umi_plugin': `true;@import "${require.resolve(
+          'antd/lib/style/color/colorPalette.less',
+        )}";`,
         ...darkTheme,
         ...compactTheme,
         ...config.theme,
       };
-      if (opts?.dark) {
-        config.theme![
-          'hack_less_umi_plugin'
-        ] = `true;@import "${require.resolve(
-          'antd/lib/style/color/colorPalette.less',
-        )}";`;
-      }
       return config;
     });
   }


### PR DESCRIPTION
https://github.com/umijs/umi/issues/4315#issuecomment-606367942

重现仓库：https://github.com/ewqazxc/umiDemo

`colorPalette is not defined`

https://unpkg.com/antd@4.1.0/dist/compact-theme.js 文件里有 color 的变量。