### PR TITLE
feat(qiankun): merge 1.x features to 2.x

### DIFF
--- a/packages/plugin-qiankun/examples/app1/.umirc.js
+++ b/packages/plugin-qiankun/examples/app1/.umirc.js
@@ -3,16 +3,6 @@ export default {
   publicPath: '/app1/',
   outputPath: './dist/app1',
   mountElementId: 'app1',
-  routes: [
-    {
-      path: '/user',
-      component: './user',
-    },
-    {
-      path: '/',
-      component: './index',
-    },
-  ],
   qiankun: {
     slave: {},
   },

--- a/packages/plugin-qiankun/examples/app1/layouts/index.js
+++ b/packages/plugin-qiankun/examples/app1/layouts/index.js
@@ -1,9 +1,8 @@
 import { Layout, Menu } from 'antd';
-import Link from 'umi/link';
+import { Link } from 'umi';
 import style from './style.less';
 
-const { SubMenu } = Menu;
-const { Header, Content, Sider } = Layout;
+const { Content, Sider } = Layout;
 
 export default ({ children }) => (
   <Layout className={style.layout}>

--- a/packages/plugin-qiankun/examples/app2/app.js
+++ b/packages/plugin-qiankun/examples/app2/app.js
@@ -1,14 +1,14 @@
 export const qiankun = {
   // 应用加载之前
   async bootstrap(props) {
-    console.log('app1 bootstrap', props);
+    console.log('app2 bootstrap', props);
   },
   // 应用 render 之前触发
   async mount(props) {
-    console.log('app1 mount', props);
+    console.log('app2 mount', props);
   },
   // 应用卸载之后触发
   async unmount(props) {
-    console.log('app1 unmount', props);
+    console.log('app2 unmount', props);
   },
 };

--- a/packages/plugin-qiankun/package.json
+++ b/packages/plugin-qiankun/package.json
@@ -4,6 +4,13 @@
   "description": "umi plugin for qiankun",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "scripts": {
+    "start": "npm-run-all --parallel start:*",
+    "start:master": "cd examples/master && umi dev",
+    "start:app1": "cd examples/app1 && umi dev",
+    "start:app2": "cd examples/app2 && umi dev",
+    "start:app3": "cd examples/app3 && umi dev"
+  },
   "files": [
     "lib",
     "master.js",
@@ -38,12 +45,13 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "address": "^1.1.2",
+    "lodash": "^4.17.15",
     "path-to-regexp": "^1.7.0",
     "qiankun": "^1.4.2"
   },
   "devDependencies": {
-    "concurrently": "^5.1.0",
     "mockjs": "^1.0.1-beta3",
+    "npm-run-all": "^4.1.5",
     "umi-request": "^1.1.0"
   }
 }

--- a/packages/plugin-qiankun/src/__tests__/common.test.ts
+++ b/packages/plugin-qiankun/src/__tests__/common.test.ts
@@ -3,7 +3,8 @@
  * @since 2019-10-22
  */
 
-import { testPathWithPrefix } from '../common';
+import { addSpecifyPrefixedRoute, testPathWithPrefix } from '../common';
+import { expectRoutes, originRoutes } from './mock';
 
 it('testPathPrefix', () => {
   // browser history
@@ -91,4 +92,17 @@ it('testPathPrefix', () => {
   expect(testPathWithPrefix('#/js/:abc/jsx/:cde', '#/js/123/jsk')).toBeFalsy();
   expect(testPathWithPrefix('#/js/:abc?', '#/js')).toBeTruthy();
   expect(testPathWithPrefix('#/js/*', '#/js/245')).toBeTruthy();
+});
+
+it('testRecursiveCoverRouter', () => {
+  // 在原route的基础上添加指定路由单测
+  expect(String(addSpecifyPrefixedRoute(originRoutes, 'test'))).toEqual(
+    String(expectRoutes),
+  );
+  expect(String(addSpecifyPrefixedRoute(originRoutes, 'test', 'app2'))).toEqual(
+    String(expectRoutes),
+  );
+  expect(String(addSpecifyPrefixedRoute(originRoutes, true, 'test'))).toEqual(
+    String(expectRoutes),
+  );
 });

--- a/packages/plugin-qiankun/src/__tests__/common.test.ts
+++ b/packages/plugin-qiankun/src/__tests__/common.test.ts
@@ -66,12 +66,16 @@ it('testPathPrefix', () => {
   expect(testPathWithPrefix('/js/:abc', '/js/123')).toBeTruthy();
   expect(testPathWithPrefix('/js/:abc/', '/js/123')).toBeFalsy();
   expect(testPathWithPrefix('/js/:abc/jsx', '/js/123/jsx')).toBeTruthy();
+  expect(testPathWithPrefix('/js/:abc/jsx', '/js/123/jsx/hello')).toBeTruthy();
   expect(testPathWithPrefix('/js/:abc/jsx', '/js/123')).toBeFalsy();
   expect(testPathWithPrefix('/js/:abc/jsx', '/js/123/css')).toBeFalsy();
   expect(
     testPathWithPrefix('/js/:abc/jsx/:cde', '/js/123/jsx/kkk'),
   ).toBeTruthy();
   expect(testPathWithPrefix('/js/:abc/jsx/:cde', '/js/123/jsk')).toBeFalsy();
+  expect(
+    testPathWithPrefix('/js/:abc/jsx/:cde', '/js/123/jsx/kkk/hello'),
+  ).toBeTruthy();
   expect(testPathWithPrefix('/js/:abc?', '/js')).toBeTruthy();
   expect(testPathWithPrefix('/js/*', '/js/245')).toBeTruthy();
 
@@ -83,11 +87,21 @@ it('testPathPrefix', () => {
   expect(testPathWithPrefix('#/:abc/js', '#/js/123')).toBeFalsy();
   expect(testPathWithPrefix('#/js/:abc', '#/js/123')).toBeTruthy();
   expect(testPathWithPrefix('#/js/:abc/', '#/js/123')).toBeFalsy();
+  expect(testPathWithPrefix('#/js/:abc/', '#/js/123/jsx')).toBeTruthy();
   expect(testPathWithPrefix('#/js/:abc/jsx', '#/js/123/jsx')).toBeTruthy();
+  expect(
+    testPathWithPrefix('#/js/:abc/jsx', '#/js/123/jsx/hello'),
+  ).toBeTruthy();
+  expect(
+    testPathWithPrefix('#/js/:abc/jsx', '#/js/123/jsx/hello?test=1'),
+  ).toBeTruthy();
   expect(testPathWithPrefix('#/js/:abc/jsx', '#/js/123')).toBeFalsy();
   expect(testPathWithPrefix('#/js/:abc/jsx', '#/js/123/css')).toBeFalsy();
   expect(
     testPathWithPrefix('#/js/:abc/jsx/:cde', '#/js/123/jsx/kkk'),
+  ).toBeTruthy();
+  expect(
+    testPathWithPrefix('#/js/:abc/jsx/:cde', '#/js/123/jsx/kkk/hello'),
   ).toBeTruthy();
   expect(testPathWithPrefix('#/js/:abc/jsx/:cde', '#/js/123/jsk')).toBeFalsy();
   expect(testPathWithPrefix('#/js/:abc?', '#/js')).toBeTruthy();

--- a/packages/plugin-qiankun/src/__tests__/mock/index.ts
+++ b/packages/plugin-qiankun/src/__tests__/mock/index.ts
@@ -1,0 +1,120 @@
+export const originSingleRoute = [
+  {
+    path: '/',
+    exact: true,
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+  {
+    path: '/user',
+    exact: true,
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+  {
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+];
+
+export const expectCoverRoute = [
+  {
+    path: '/',
+    exact: true,
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+  {
+    path: '/test/user',
+    exact: true,
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+  {
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+];
+
+export const originRoutes = [
+  {
+    path: '/',
+    routes: [
+      {
+        path: '/',
+        exact: true,
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+      {
+        path: '/user',
+        exact: true,
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+      {
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+    ],
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+  {
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+];
+
+export const expectRoutes = [
+  {
+    path: '/app2',
+    routes: [
+      {
+        path: '/',
+        exact: true,
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+      {
+        path: '/test/user',
+        exact: true,
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+      {
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+    ],
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+  {
+    path: '/',
+    routes: [
+      {
+        path: '/',
+        exact: true,
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+      {
+        path: '/user',
+        exact: true,
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+      {
+        _title: 'app2',
+        _title_default: 'app2',
+      },
+    ],
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+  {
+    _title: 'app2',
+    _title_default: 'app2',
+  },
+];

--- a/packages/plugin-qiankun/src/common.ts
+++ b/packages/plugin-qiankun/src/common.ts
@@ -36,7 +36,9 @@ function testPathWithStaticPrefix(pathPrefix: string, realPath: string) {
 }
 
 function testPathWithDynamicRoute(dynamicRoute: string, realPath: string) {
-  return !!pathToRegexp(dynamicRoute, { strict: true }).exec(realPath);
+  return !!pathToRegexp(dynamicRoute, { strict: true, end: false }).exec(
+    realPath,
+  );
 }
 
 export function testPathWithPrefix(pathPrefix: string, realPath: string) {

--- a/packages/plugin-qiankun/src/common.ts
+++ b/packages/plugin-qiankun/src/common.ts
@@ -6,8 +6,7 @@
 import { cloneDeep } from 'lodash';
 import pathToRegexp from 'path-to-regexp';
 import { IRoute } from 'umi';
-
-import { keepOriginalRoutesOption } from './types';
+import { SlaveOptions } from './types';
 
 export const defaultMountContainerId = 'root-subapp';
 
@@ -64,7 +63,7 @@ const recursiveCoverRouter = (source: Array<IRoute>, nameSpacePath: string) =>
 
 export const addSpecifyPrefixedRoute = (
   originRoute: Array<IRoute>,
-  keepOriginalRoutes: keepOriginalRoutesOption,
+  keepOriginalRoutes: SlaveOptions['keepOriginalRoutes'],
   pkgName?: string,
 ) => {
   const copyBase = originRoute.filter(_ => _.path === '/');

--- a/packages/plugin-qiankun/src/index.ts
+++ b/packages/plugin-qiankun/src/index.ts
@@ -1,5 +1,5 @@
-import { IApi } from 'umi';
 import assert from 'assert';
+import { IApi } from 'umi';
 import master from './master';
 import slave from './slave';
 
@@ -18,11 +18,15 @@ export default function(api: IApi) {
     },
   });
 
-  const { master: masterOpts, slave: slaveOpts } = api.userConfig.qiankun || {};
+  const {
+    master: masterOpts,
+    slave: slaveOpts,
+    shouldNotModifyRuntimePublicPath = false,
+  } = api.userConfig.qiankun || {};
   assert(!(masterOpts && slaveOpts), '请勿同时配置 master 和 slave 配置项。');
 
   if (slaveOpts) {
-    slave(api, slaveOpts);
+    slave(api, { ...slaveOpts, shouldNotModifyRuntimePublicPath });
   }
   if (masterOpts) {
     master(api, masterOpts);

--- a/packages/plugin-qiankun/src/index.ts
+++ b/packages/plugin-qiankun/src/index.ts
@@ -18,15 +18,11 @@ export default function(api: IApi) {
     },
   });
 
-  const {
-    master: masterOpts,
-    slave: slaveOpts,
-    shouldNotModifyRuntimePublicPath = false,
-  } = api.userConfig.qiankun || {};
+  const { master: masterOpts, slave: slaveOpts } = api.userConfig.qiankun || {};
   assert(!(masterOpts && slaveOpts), '请勿同时配置 master 和 slave 配置项。');
 
   if (slaveOpts) {
-    slave(api, { ...slaveOpts, shouldNotModifyRuntimePublicPath });
+    slave(api, slaveOpts);
   }
   if (masterOpts) {
     master(api, masterOpts);

--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -9,14 +9,10 @@ import {
   testPathWithPrefix,
   toArray,
 } from '../common';
-import { Options } from '../types';
+import { MasterOptions } from '../types';
 
-export default function(api: IApi, options: Options) {
-  const { registerRuntimeKeyInIndex = false } = options || {};
+export default function(api: IApi, options: MasterOptions) {
   api.addRuntimePlugin(() => require.resolve('./runtimePlugin'));
-  if (!registerRuntimeKeyInIndex) {
-    api.addRuntimePluginKey(() => 'qiankun');
-  }
 
   api.modifyDefaultConfig(config => ({
     ...config,

--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 // eslint-disable-next-line import/no-unresolved
 import { IApi, IRoute } from 'umi';
 import {
-  defaultHistoryMode,
+  defaultHistoryType,
   defaultMasterRootId,
   testPathWithPrefix,
   toArray,
@@ -48,39 +48,45 @@ export default function(api: IApi, options: Options) {
     const modifyAppRoutes = () => {
       api.modifyRoutes(routes => {
         const {
-          config: { history: masterHistory = defaultHistoryMode },
+          config: { history },
         } = api;
 
+        const masterHistoryType = history?.type || defaultHistoryType;
         const newRoutes = routes.map(route => {
           if (route.path === '/' && route.routes && route.routes.length) {
-            apps.forEach(({ history: slaveHistory = masterHistory, base }) => {
-              // 当子应用的 history mode 跟主应用一致时，为避免出现 404 手动为主应用创建一个 path 为 子应用 rule 的空 div 路由组件
-              if (slaveHistory === masterHistory) {
-                const baseConfig = toArray(base);
+            apps.forEach(
+              ({ history: slaveHistory = masterHistoryType, base }) => {
+                // 当子应用的 history mode 跟主应用一致时，为避免出现 404 手动为主应用创建一个 path 为 子应用 rule 的空 div 路由组件
+                if (slaveHistory === masterHistoryType) {
+                  const baseConfig = toArray(base);
 
-                baseConfig.forEach(basePath => {
-                  const routeWithPrefix = findRouteWithPrefix(routes, basePath);
+                  baseConfig.forEach(basePath => {
+                    const routeWithPrefix = findRouteWithPrefix(
+                      routes,
+                      basePath,
+                    );
 
-                  // 应用没有自己配置过 basePath 相关路由，则自动加入 mock 的路由
-                  if (!routeWithPrefix) {
-                    route.routes!.unshift({
-                      path: basePath,
-                      exact: false,
-                      component: `() => {
+                    // 应用没有自己配置过 basePath 相关路由，则自动加入 mock 的路由
+                    if (!routeWithPrefix) {
+                      route.routes!.unshift({
+                        path: basePath,
+                        exact: false,
+                        component: `() => {
                         if (process.env.NODE_ENV === 'development') {
                           console.log('${basePath} 404 mock rendered');
                         }
 
                         return React.createElement('div');
                       }`,
-                    });
-                  } else {
-                    // 若用户已配置过跟应用 base 重名的路由，则强制将该路由 exact 设置为 false，目的是兼容之前遗留的错误用法的场景
-                    routeWithPrefix.exact = false;
-                  }
-                });
-              }
-            });
+                      });
+                    } else {
+                      // 若用户已配置过跟应用 base 重名的路由，则强制将该路由 exact 设置为 false，目的是兼容之前遗留的错误用法的场景
+                      routeWithPrefix.exact = false;
+                    }
+                  });
+                }
+              },
+            );
           }
 
           return route;
@@ -99,8 +105,9 @@ export default function(api: IApi, options: Options) {
 
   api.onGenerateFiles(() => {
     const {
-      config: { history = defaultHistoryMode },
+      config: { history },
     } = api;
+    const masterHistoryType = history?.type || defaultHistoryType;
     const rootExports = `
 window.g_rootExports = ${
       existsSync(rootExportsFile) ? `require('@/rootExports')` : `{}`
@@ -115,7 +122,7 @@ window.g_rootExports = ${
     api.writeTmpFile({
       path: 'plugin-qiankun/subAppsConfig.json',
       content: JSON.stringify({
-        masterHistory: history,
+        masterHistoryType,
         ...options,
       }),
     });

--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -99,9 +99,15 @@ export default function(api: IApi, options: Options) {
     modifyAppRoutes();
   }
 
-  const rootExportsFile = join(api.paths.absSrcPath!, 'rootExports.js');
+  const rootExportsJsFile = join(api.paths.absSrcPath!, 'rootExports.js');
+  const rootExportsTsFile = join(api.paths.absSrcPath!, 'rootExports.ts');
+  const rootExportsJsFileExisted = existsSync(rootExportsJsFile);
+  const rootExportsFileExisted =
+    rootExportsJsFileExisted || existsSync(rootExportsTsFile);
 
-  api.addTmpGenerateWatcherPaths(() => rootExportsFile);
+  api.addTmpGenerateWatcherPaths(() =>
+    rootExportsJsFileExisted ? rootExportsJsFile : rootExportsTsFile,
+  );
 
   api.onGenerateFiles(() => {
     const {
@@ -110,7 +116,7 @@ export default function(api: IApi, options: Options) {
     const masterHistoryType = history?.type || defaultHistoryType;
     const rootExports = `
 window.g_rootExports = ${
-      existsSync(rootExportsFile) ? `require('@/rootExports')` : `{}`
+      rootExportsFileExisted ? `require('@/rootExports')` : `{}`
     };
     `.trim();
 

--- a/packages/plugin-qiankun/src/master/runtimePlugin.ts
+++ b/packages/plugin-qiankun/src/master/runtimePlugin.ts
@@ -113,7 +113,7 @@ export async function render(oldRender: typeof noop) {
       }),
     ),
     lifeCycles,
-    { ...otherConfigs },
+    otherConfigs,
   );
 
   if (defer) {

--- a/packages/plugin-qiankun/src/master/runtimePlugin.ts
+++ b/packages/plugin-qiankun/src/master/runtimePlugin.ts
@@ -109,7 +109,9 @@ export async function render(oldRender: typeof noop) {
             }),
           render: ({ appContent, loading }) => {
             if (process.env.NODE_ENV === 'development') {
-              console.info(`app ${name} loading ${loading}`);
+              console.info(
+                `[@umijs/plugin-qiankun]: app ${name} loading ${loading}`,
+              );
             }
 
             if (mountElementId) {
@@ -122,6 +124,9 @@ export async function render(oldRender: typeof noop) {
                 });
                 ReactDOM.render(subApp, container);
               }
+            } else if (process.env.NODE_ENV === 'development') {
+              console.warn(`[@umijs/plugin-qiankun]: Your ${name} app container with id ${mountElementId} is not
+               ready, that may cause an unexpected behavior!`);
             }
           },
           props: {

--- a/packages/plugin-qiankun/src/master/runtimePlugin.ts
+++ b/packages/plugin-qiankun/src/master/runtimePlugin.ts
@@ -12,12 +12,13 @@ import ReactDOM from 'react-dom';
 // @ts-ignore
 import { ApplyPluginsType, plugin } from 'umi';
 import {
+  defaultHistoryType,
   defaultMountContainerId,
   noop,
   testPathWithPrefix,
   toArray,
 } from '../common';
-import { App, HistoryType, Options } from '../types';
+import { App, HistoryType, MasterOptions } from '../types';
 
 async function getMasterRuntime() {
   const config = plugin.applyPlugins({
@@ -76,11 +77,11 @@ export async function render(oldRender: typeof noop) {
     prefetch = true,
     defer = false,
     lifeCycles,
-    masterHistoryType,
+    masterHistoryType = defaultHistoryType,
     ...otherConfigs
   } = {
-    ...(subAppConfig as Options),
-    ...(runtimeConfig as Options),
+    ...(subAppConfig as MasterOptions),
+    ...(runtimeConfig as MasterOptions),
   };
   assert(
     apps && apps.length,

--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -4,20 +4,16 @@ import { isString } from 'lodash';
 import { join } from 'path';
 import { IApi } from 'umi';
 import { addSpecifyPrefixedRoute, defaultSlaveRootId } from '../common';
-import { Options } from '../types';
+import { SlaveOptions } from '../types';
 
 const localIpAddress = process.env.USE_REMOTE_IP ? address.ip() : 'localhost';
 
-export default function(api: IApi, options: Options) {
+export default function(api: IApi, options: SlaveOptions) {
   const {
-    registerRuntimeKeyInIndex = false,
     keepOriginalRoutes = false,
     shouldNotModifyRuntimePublicPath = false,
   } = options || {};
   api.addRuntimePlugin(() => require.resolve('./runtimePlugin'));
-  if (!registerRuntimeKeyInIndex) {
-    api.addRuntimePluginKey(() => 'qiankun');
-  }
 
   const lifecyclePath = require.resolve('./lifecycles');
   // eslint-disable-next-line import/no-dynamic-require, global-require

--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -9,8 +9,11 @@ import { Options } from '../types';
 const localIpAddress = process.env.USE_REMOTE_IP ? address.ip() : 'localhost';
 
 export default function(api: IApi, options: Options) {
-  const { registerRuntimeKeyInIndex = false, keepOriginalRoutes = false } =
-    options || {};
+  const {
+    registerRuntimeKeyInIndex = false,
+    keepOriginalRoutes = false,
+    shouldNotModifyRuntimePublicPath = false,
+  } = options || {};
   api.addRuntimePlugin(() => require.resolve('./runtimePlugin'));
   if (!registerRuntimeKeyInIndex) {
     api.addRuntimePluginKey(() => 'qiankun');
@@ -28,7 +31,10 @@ export default function(api: IApi, options: Options) {
     runtimePublicPath: true,
   }));
 
-  if (api.service.userConfig.runtimePublicPath !== false) {
+  if (
+    api.service.userConfig.runtimePublicPath !== false &&
+    !shouldNotModifyRuntimePublicPath
+  ) {
     api.modifyPublicPathStr(
       () =>
         `window.__INJECTED_PUBLIC_PATH_BY_QIANKUN__ || "${

--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -1,14 +1,16 @@
 import address from 'address';
 import assert from 'assert';
+import { isString } from 'lodash';
 import { join } from 'path';
 import { IApi } from 'umi';
-import { defaultSlaveRootId } from '../common';
+import { addSpecifyPrefixedRoute, defaultSlaveRootId } from '../common';
 import { Options } from '../types';
 
 const localIpAddress = process.env.USE_REMOTE_IP ? address.ip() : 'localhost';
 
 export default function(api: IApi, options: Options) {
-  const { registerRuntimeKeyInIndex = false } = options || {};
+  const { registerRuntimeKeyInIndex = false, keepOriginalRoutes = false } =
+    options || {};
   api.addRuntimePlugin(() => require.resolve('./runtimePlugin'));
   if (!registerRuntimeKeyInIndex) {
     api.addRuntimePluginKey(() => 'qiankun');
@@ -121,4 +123,13 @@ export default function(api: IApi, options: Options) {
     }
     `,
   );
+
+  api.modifyRoutes(routes => {
+    // 开启keepOriginalRoutes配置
+    if (keepOriginalRoutes === true || isString(keepOriginalRoutes)) {
+      return addSpecifyPrefixedRoute(routes, keepOriginalRoutes, pkgName);
+    }
+
+    return routes;
+  });
 }

--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -91,8 +91,7 @@ export default function(api: IApi, options: Options) {
       export const Context = createContext(null);
       export function useRootExports() {
         return useContext(Context);
-      };
-        `.trim(),
+      };`.trim(),
     });
   });
 

--- a/packages/plugin-qiankun/src/types.ts
+++ b/packages/plugin-qiankun/src/types.ts
@@ -26,6 +26,7 @@ export type Options = {
   masterHistoryType: HistoryType;
   registerRuntimeKeyInIndex?: boolean; // 仅做插件本身透传用，开发者无需关心
   keepOriginalRoutes?: keepOriginalRoutesOption;
+  shouldNotModifyRuntimePublicPath?: boolean;
 } & ImportEntryOpts;
 
 export type keepOriginalRoutesOption = boolean | string;
@@ -33,4 +34,5 @@ export type keepOriginalRoutesOption = boolean | string;
 export type GlobalOptions = {
   master?: Options;
   slave?: Options;
+  shouldNotModifyRuntimePublicPath?: boolean;
 };

--- a/packages/plugin-qiankun/src/types.ts
+++ b/packages/plugin-qiankun/src/types.ts
@@ -4,7 +4,8 @@
  */
 
 import { LifeCycles } from 'qiankun';
-// eslint-disable-next-line import/no-unresolved
+import { ImportEntryOpts } from 'import-html-entry';
+// @ts-ignore
 import { IConfig } from 'umi-types';
 
 export type App = {
@@ -22,7 +23,7 @@ export type Options = {
   lifeCycles?: LifeCycles<object>;
   masterHistory: IConfig['history'];
   registerRuntimeKeyInIndex?: boolean; // 仅做插件本身透传用，开发者无需关心
-};
+} & ImportEntryOpts;
 
 export type GlobalOptions = {
   master?: Options;

--- a/packages/plugin-qiankun/src/types.ts
+++ b/packages/plugin-qiankun/src/types.ts
@@ -3,17 +3,19 @@
  * @since 2019-06-20
  */
 
-import { LifeCycles } from 'qiankun';
 import { ImportEntryOpts } from 'import-html-entry';
+import { LifeCycles } from 'qiankun';
 // @ts-ignore
 import { IConfig } from 'umi-types';
 
+export type HistoryType = 'browser' | 'hash';
 export type App = {
   name: string;
   entry: string | { scripts: string[]; styles: string[] };
   base: string | string[];
+  history?: HistoryType;
   props?: any;
-} & Pick<IConfig, 'history' | 'mountElementId'>;
+} & Pick<IConfig, 'mountElementId'>;
 
 export type Options = {
   apps: App[];
@@ -21,9 +23,12 @@ export type Options = {
   prefetch: boolean;
   defer?: boolean;
   lifeCycles?: LifeCycles<object>;
-  masterHistory: IConfig['history'];
+  masterHistoryType: HistoryType;
   registerRuntimeKeyInIndex?: boolean; // 仅做插件本身透传用，开发者无需关心
+  keepOriginalRoutes?: keepOriginalRoutesOption;
 } & ImportEntryOpts;
+
+export type keepOriginalRoutesOption = boolean | string;
 
 export type GlobalOptions = {
   master?: Options;

--- a/packages/plugin-qiankun/src/types.ts
+++ b/packages/plugin-qiankun/src/types.ts
@@ -17,22 +17,16 @@ export type App = {
   props?: any;
 } & Pick<IConfig, 'mountElementId'>;
 
-export type Options = {
+export type MasterOptions = {
   apps: App[];
   jsSandbox: boolean;
   prefetch: boolean;
   defer?: boolean;
   lifeCycles?: LifeCycles<object>;
-  masterHistoryType: HistoryType;
-  registerRuntimeKeyInIndex?: boolean; // 仅做插件本身透传用，开发者无需关心
-  keepOriginalRoutes?: keepOriginalRoutesOption;
-  shouldNotModifyRuntimePublicPath?: boolean;
+  masterHistoryType?: HistoryType;
 } & ImportEntryOpts;
 
-export type keepOriginalRoutesOption = boolean | string;
-
-export type GlobalOptions = {
-  master?: Options;
-  slave?: Options;
+export type SlaveOptions = {
+  keepOriginalRoutes?: boolean | string;
   shouldNotModifyRuntimePublicPath?: boolean;
 };


### PR DESCRIPTION
* 支持使用 rootExports.ts
* 支持传入 shouldNotModifyPublicPath 参数来关闭 qiankun 注入的 runtimePublicPath
* 修复路由正则匹配过于精确的问题
* 子应用 props 中注入 getMatchedBase 方法用于获取当前匹配到的动态前缀
* 增加 keepOriginalRoutes 配置保持应用原路由信息


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/plugins/138)
<!-- Reviewable:end -->
