### PR TITLE
fix: dark and compact conflict

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -10,17 +10,19 @@ export default (api: IApi) => {
   api.describe({
     config: {
       schema(joi) {
-        return joi
-          .object({
-            dark: joi.boolean(),
-            compact: joi.boolean(),
-          })
-          .oxor('dark', 'compact')
-          .error(
-            new Error(
-              'The dark and compact mode cannot be enabled at the same time.',
-            ),
-          );
+        return joi.object({
+          dark: joi.boolean(),
+          compact: joi.boolean().when('dark', {
+            is: true,
+            then: joi
+              .valid(false)
+              .error(
+                new Error(
+                  'The dark and compact mode cannot be enabled at the same time.',
+                ),
+              ),
+          }),
+        });
       },
     },
   });


### PR DESCRIPTION
三个配置互斥时，就不能用这个 schema 了 

![image](https://user-images.githubusercontent.com/13595509/78749392-ba90c700-79a0-11ea-94c8-f70931833252.png)


![image](https://user-images.githubusercontent.com/13595509/78749401-be244e00-79a0-11ea-9e40-ae7bff21a52c.png)


![image](https://user-images.githubusercontent.com/13595509/78749405-c086a800-79a0-11ea-9648-a5d8ff429180.png)
