### PR TITLE
feat(antd-plugins): support antd mixin theme mode

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -12,16 +12,7 @@ export default (api: IApi) => {
       schema(joi) {
         return joi.object({
           dark: joi.boolean(),
-          compact: joi.boolean().when('dark', {
-            is: true,
-            then: joi
-              .valid(false)
-              .error(
-                new Error(
-                  'The dark and compact mode cannot be enabled at the same time.',
-                ),
-              ),
-          }),
+          compact: joi.boolean(),
         });
       },
     },


### PR DESCRIPTION
Now, antd supports the mixin theme mode.

ref: 
https://github.com/ant-design/ant-design/pull/22934
https://github.com/umijs/plugins/pull/131