### PR TITLE
feat: layout custom children need passing parameters

### DIFF
--- a/packages/plugin-layout/src/layout/index.tsx
+++ b/packages/plugin-layout/src/layout/index.tsx
@@ -85,7 +85,7 @@ const BasicLayout = (props: any) => {
       <ErrorBoundary>
         <WithExceptionOpChildren currentPathConfig={currentPathConfig}>
           {userConfig.childrenRender
-            ? userConfig.childrenRender(children)
+            ? userConfig.childrenRender(children, props)
             : children}
         </WithExceptionOpChildren>
       </ErrorBoundary>


### PR DESCRIPTION
其实应该直接传props就可以的，考虑到，可能已经有现有项目使用，为了不影响，再传一个第二参数。

自定义渲染在运行时配置时，没有其他途径取到当前路由信息。不传递参数，不便于内部的逻辑判断。