### PR TITLE
feat: Import on Demand Antd

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -16,11 +16,6 @@ export default {
   extraBabelPlugins: [
     [
       'babel-plugin-import',
-      { libraryName: 'antd-mobile', libraryDirectory: 'es', style: true },
-      'antd-mobile',
-    ],
-    [
-      'babel-plugin-import',
       { libraryName: 'antd', libraryDirectory: 'es', style: true },
       'antd',
     ],

--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -13,4 +13,16 @@ export default {
   cjs: { type: 'babel', lazy: true },
   disableTypeCheck: true,
   pkgs: [...headPkgs, ...tailPkgs],
+  extraBabelPlugins: [
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd-mobile', libraryDirectory: 'es', style: true },
+      'antd-mobile',
+    ],
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd', libraryDirectory: 'es', style: true },
+      'antd',
+    ],
+  ],
 };


### PR DESCRIPTION
Close: https://github.com/umijs/next-app/issues/8

引入 plugin-layout 插件导致全量引入 antd
配置前 umi 3.09MB antd 2.88MB
![image](https://user-images.githubusercontent.com/11746742/79101843-0e821e00-7d9c-11ea-972d-408751e1ebae.png)
配置后 umi 2.07MB antd 774.34KB
![image](https://user-images.githubusercontent.com/11746742/79101883-25287500-7d9c-11ea-9344-3e9606245804.png)