### PR TITLE
fix: update antd theme plugin config

### DIFF
--- a/packages/plugin-antd/package.json
+++ b/packages/plugin-antd/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "antd": "^4.1.2",
+    "antd": "^4.1.3",
     "antd-mobile": "^2.3.1"
   }
 }

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -32,19 +32,10 @@ export default (api: IApi) => {
 
   if (opts?.dark || opts?.compact) {
     // support dark mode, user use antd 4 by default
-    const defaultTheme = require('antd/dist/default-theme');
-    const darkTheme = opts?.dark ? require('antd/dist/dark-theme') : {};
-    const compactTheme = opts?.compact
-      ? require('antd/dist/compact-theme')
-      : {};
+    const { getThemeVariables } = require('antd/dist/theme');
     api.modifyDefaultConfig(config => {
       config.theme = {
-        hack_less_umi_plugin: `true;@import "${require.resolve(
-          'antd/lib/style/color/colorPalette.less',
-        )}";`,
-        ...defaultTheme,
-        ...darkTheme,
-        ...compactTheme,
+        ...getThemeVariables(opts),
         ...config.theme,
       };
       return config;


### PR DESCRIPTION
ref: https://github.com/ant-design/ant-design/pull/23171

Closes https://github.com/umijs/plugins/pull/159, https://github.com/umijs/umi/issues/4513

4.1.3 使用了 `getThemeVariables` 来做混合模式配置，以后这部分工作让 antd 那边的 `getThemeVariables` 来做比较好。