### PR TITLE
fix: menu icon inoperative

### DIFF
--- a/packages/plugin-layout/src/index.ts
+++ b/packages/plugin-layout/src/index.ts
@@ -32,6 +32,10 @@ function formatter(data: MenuDataItem[]): string[] {
   }
   let icons: string[] = [];
   (data || []).forEach((item = { path: '/' }) => {
+    // 兼容旧的写法 menu:{icon:""}
+    if (item.menu) {
+      item = { ...item, ...item.menu };
+    }
     if (item.icon) {
       const { icon } = item;
       const v4IconName = toHump(icon.replace(icon[0], icon[0].toUpperCase()));

--- a/packages/plugin-layout/src/runtime.tsx.tpl
+++ b/packages/plugin-layout/src/runtime.tsx.tpl
@@ -25,13 +25,17 @@ function formatter(data: MenuDataItem[]): MenuDataItem[] {
     return data;
   }
   (data || []).forEach((item = { path: '/' }) => {
-    if (item.icon && typeof item.icon === "string") {
-      const { icon } = item;
+    // 兼容旧的写法 menu:{icon:""}
+    const icon = item.icon ? item.icon : item.menu ? item.menu.icon : '';
+    if (icon && typeof icon === "string") {
       const v4IconName = toHump(icon.replace(icon[0], icon[0].toUpperCase()));
       const NewIcon = allIcons[icon] || allIcons[`${v4IconName}Outlined`];
       if (NewIcon) {
         try {
-          item.icon = react.createElement(NewIcon);
+          if (item.icon)
+            item.icon = react.createElement(NewIcon);
+          if (item.menu)
+            item.menu.icon = react.createElement(NewIcon);
         } catch (error) {
           console.log(error);
         }


### PR DESCRIPTION
Close: https://github.com/umijs/umi/issues/4483

支持旧的写法
```
{
        path: '/',
        component: '@/pages/index',
        menu: { // 兼容此写法
            name: '欢迎',
            icon: 'smile',
        }
}
```