### PR TITLE
fix: 修复 layout 配置 menu 显示指定为 false 不生效 

### DIFF
--- a/example/.umirc.ts
+++ b/example/.umirc.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       name: 'request 测试',
       path: '/request',
       component: './request',
+      menu: false,
     },
     {
       name: '首页',

--- a/packages/plugin-layout/src/utils/getMenuFromRoute.ts
+++ b/packages/plugin-layout/src/utils/getMenuFromRoute.ts
@@ -27,6 +27,7 @@ function formatter(
         item =>
           item &&
           !item.unaccessible && // 是否没有权限查看
+          item.menu !== false && // 显示指定在 menu 中隐藏该项
           (item.name || // 兼容老版本 route 配置
           item.flatMenu || // 是否打平 menu
           (item.menu && (item.menu.name || item.menu.flatMenu)) || // 正确配置了 menu


### PR DESCRIPTION
之前为了兼容老得写法，所以配置了 name 就等同于配置了 menu，优先级高于 menu：false。

然后存在 menu 为 false 时，name 仍用于 document.title 等用途的场景，所以调高优先级，menu 显示指定为 false 时，不在侧边栏中展示，与文档保持一致。

Close https://github.com/umijs/umi/issues/4179