### PR TITLE
fix(qiankun): 拆分 qiankun 配置加载

### DIFF
--- a/packages/plugin-qiankun/package.json
+++ b/packages/plugin-qiankun/package.json
@@ -47,7 +47,7 @@
     "address": "^1.1.2",
     "lodash": "^4.17.15",
     "path-to-regexp": "^1.7.0",
-    "qiankun": "^2.0.0-2"
+    "qiankun": "^2.0.7"
   },
   "devDependencies": {
     "mockjs": "^1.0.1-beta3",

--- a/packages/plugin-qiankun/src/index.ts
+++ b/packages/plugin-qiankun/src/index.ts
@@ -1,7 +1,4 @@
-import assert from 'assert';
 import { IApi } from 'umi';
-import master from './master';
-import slave from './slave';
 
 export default function(api: IApi) {
   api.addRuntimePluginKey(() => 'qiankun');
@@ -10,21 +7,19 @@ export default function(api: IApi) {
     key: 'qiankun',
     config: {
       schema(joi) {
-        return joi.object({
-          slave: joi.object(),
-          master: joi.object(),
-        });
+        return joi
+          .object()
+          .keys({
+            slave: joi.object(),
+            master: joi.object(),
+          })
+          .without('slave', 'master');
       },
     },
   });
 
-  const { master: masterOpts, slave: slaveOpts } = api.userConfig.qiankun || {};
-  assert(!(masterOpts && slaveOpts), '请勿同时配置 master 和 slave 配置项。');
-
-  if (slaveOpts) {
-    slave(api, slaveOpts);
-  }
-  if (masterOpts) {
-    master(api, masterOpts);
-  }
+  api.registerPlugins([
+    require.resolve('./master'),
+    require.resolve('./slave'),
+  ]);
 }

--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -8,7 +8,13 @@ import { defaultHistoryType, defaultMasterRootId } from '../common';
 import { MasterOptions } from '../types';
 import modifyRoutes from './modifyRoutes';
 
-export default function(api: IApi, options: MasterOptions) {
+export default function(api: IApi) {
+  api.describe({
+    enableBy() {
+      return api.userConfig.qiankun && api.userConfig.qiankun.master;
+    },
+  });
+
   api.addRuntimePlugin(() => require.resolve('./runtimePlugin'));
 
   api.modifyDefaultConfig(config => ({
@@ -18,6 +24,7 @@ export default function(api: IApi, options: MasterOptions) {
   }));
 
   // apps 可能在构建期为空
+  const options: MasterOptions = api.userConfig.qiankun.master;
   const { apps = [], routeBindingAlias = 'microApp' } = options || {};
   modifyRoutes(api, apps, routeBindingAlias);
 

--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -8,7 +8,14 @@ import { SlaveOptions } from '../types';
 
 const localIpAddress = process.env.USE_REMOTE_IP ? address.ip() : 'localhost';
 
-export default function(api: IApi, options: SlaveOptions) {
+export default function(api: IApi) {
+  api.describe({
+    enableBy() {
+      return api.userConfig.qiankun && api.userConfig.qiankun.slave;
+    },
+  });
+
+  const options: SlaveOptions = api.userConfig.qiankun.slave;
   const {
     keepOriginalRoutes = false,
     shouldNotModifyRuntimePublicPath = false,


### PR DESCRIPTION
将 qiankun 的 master 和 slave 作为两个独立的子插件注册到 qiankun 插件，从而使得其他插件可以通过 modifyConfig 方法唤起 qiankun 插件。