### PR TITLE
feat(locale): export Selectlang component

### DIFF
--- a/example/app.tsx
+++ b/example/app.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InitialState, request as umiRequest } from 'umi';
+import { InitialState, request as umiRequest, SelectLang } from 'umi';
 import { MenuItem } from '@umijs/plugin-layout';
 
 export function render(oldRender: Function) {
@@ -19,13 +19,27 @@ export const layout = {
   rightRender: (initialState: any, setInitialState: any) => {
     console.log('initialState', initialState);
     return (
-      <button
-        onClick={() => {
-          setInitialState({ name: 'SS' });
-        }}
-      >
-        {initialState.name}
-      </button>
+      <>
+        <SelectLang
+          postLocalesData={locales => [
+            ...locales,
+            {
+              lang: 'nl-NL', // 荷兰语的 key 与 antd 保持一致
+              label: 'Nederlands', // 荷兰语的“荷兰语”
+              icon: '🇳🇱', // 荷兰国旗
+              title: 'Taal', // 荷兰语的“语言”
+            },
+          ]}
+          onItemClick={({ key }) => alert(key)}
+        />
+        <button
+          onClick={() => {
+            setInitialState({ name: 'SS' });
+          }}
+        >
+          {initialState.name}
+        </button>
+      </>
     );
   },
   patchMenus: (menus: MenuItem[], initialInfo: InitialState) => {

--- a/example/locales/nl-NL.js
+++ b/example/locales/nl-NL.js
@@ -1,0 +1,3 @@
+export default {
+  name: '你好，{name}',
+};

--- a/packages/plugin-locale/docs/README.md
+++ b/packages/plugin-locale/docs/README.md
@@ -180,6 +180,32 @@ setLocale('zh-TW', true);
 setLocale('zh-TW', false);
 ```
 
+### <SelectLang />
+
+选择语言的展示组件。可以通过开启 locale 插件，从 umi 中获取该组件。只有当项目依赖 antd, 同时项目 /locales 文件夹下有超过两个语言文件时才会显示。可配置的属性有：
+
+- postLocaleData, 默认包含 "简体中文" 、"繁体中文"、 "英文" 、"葡萄牙语"四种语言配置,当需要展示其他语言时，可以通过配置 postLocaleData 来扩展，格式如下所示。
+- globalIconClassName, 全球图标的样式。
+- onItemClick, 切换语言时的回掉函数，默认会 setLocale。
+- <[Dropdown/](https://ant.design/components/dropdown-cn/#API)> 的所有 API。
+
+```tsx
+import { SelectLang } from 'umi';
+
+<SelectLang
+  postLocaleData={locales=> ([
+    ...locales,
+    {
+      lang: 'nl-NL', // 语言的 key 与 antd & locales 下的文件名保持一致
+      label: 'Nederlands', // 下拉菜单中展示的语言名
+      icon: '🇳🇱', // 下拉菜单中展示的 icon （一般为国旗
+      title: 'Taal', // 鼠标浮上全球图标时展示的文案（一般为“语言”这个词的各种翻译
+    }
+  ])}
+  onItemClick={({ key }) => alert(key)}
+>
+```
+
 ### 运行时配置
 
 支持运行时对国际化做一些扩展与定制，例如自定义语言识别等。

--- a/packages/plugin-locale/package.json
+++ b/packages/plugin-locale/package.json
@@ -33,7 +33,8 @@
     "intl": "1.2.5",
     "moment": "2.x",
     "react-intl": "3.12.0",
-    "warning": "^4.0.3"
+    "warning": "^4.0.3",
+    "@ant-design/icons": "^4.1.0"
   },
   "devDependencies": {
     "@types/warning": "^3.0.0"

--- a/packages/plugin-locale/src/templates/SelectLang.tpl
+++ b/packages/plugin-locale/src/templates/SelectLang.tpl
@@ -57,6 +57,33 @@ const transformArrayToObject = (allLangUIConfig:LocalData[])=>{
   }, {});
 }
 
+const defaultLangUConfigMap = {
+  'zh-CN': {
+    lang: 'zh-CN',
+    label: '简体中文',
+    icon: '🇨🇳',
+    title: '语言'
+  },
+  'zh-TW': {
+    lang: 'zh-TW',
+    label: '繁体中文',
+    icon: '🇭🇰',
+    title: '語言'
+  },
+  'en-US': {
+    lang: 'en-US',
+    label: 'English',
+    icon: '🇺🇸',
+    title: 'Language'
+  },
+  'pt-BR': {
+    lang: 'pt-BR',
+    label: 'Português',
+    icon: '🇧🇷',
+    title: 'Idiomas'
+  }
+};
+
 export const SelectLang: React.FC<SelectLangProps> = (props) => {
   {{#ShowSelectLang}}
   const { globalIconClassName, postLocalesData, onItemClick, ...restProps } = props;
@@ -64,32 +91,16 @@ export const SelectLang: React.FC<SelectLangProps> = (props) => {
 
   const changeLang = ({ key }: ClickParam): void => setLocale(key);
 
-  const defaultLangUConfig = [
-    {
-      lang: 'zh-CN',
-      label: '简体中文',
-      icon: '🇨🇳',
-      title: '语言',
-    },
-    {
-      lang: 'zh-TW',
-      label: '繁体中文',
-      icon: '🇭🇰',
-      title: '語言',
-    },
-    {
-      lang: 'en-US',
-      label: 'English',
-      icon: '🇺🇸',
-      title: 'Language',
-    },
-    {
-      lang: 'pt-BR',
-      label: 'Português',
-      icon: '🇧🇷',
-      title: 'Idiomas',
-    }
-  ]
+  const defaultLangUConfig = getAllLocales().map(
+    key =>
+      defaultLangUConfigMap[key] || {
+        lang: key,
+        label: key,
+        icon: '🌐',
+        title: key
+      }
+  );
+
 
   const allLangUIConfig = transformArrayToObject(postLocalesData ?  postLocalesData(defaultLangUConfig): defaultLangUConfig);
 

--- a/packages/plugin-locale/src/templates/SelectLang.tpl
+++ b/packages/plugin-locale/src/templates/SelectLang.tpl
@@ -1,0 +1,131 @@
+import React from 'react';
+{{#Antd}}
+import { GlobalOutlined } from '{{{ iconsPkgPath }}}';
+import { Menu, Dropdown } from 'antd';
+import { ClickParam } from 'antd/{{{antdFiles}}}/menu';
+import { DropDownProps } from 'antd/{{{antdFiles}}}/dropdown';
+{{/Antd}}
+import { getLocale, setLocale } from './localeExports';
+
+{{#Antd}}
+export interface HeaderDropdownProps extends DropDownProps {
+  overlayClassName?: string;
+  placement?:
+    | 'bottomLeft'
+    | 'bottomRight'
+    | 'topLeft'
+    | 'topCenter'
+    | 'topRight'
+    | 'bottomCenter';
+}
+
+const HeaderDropdown: React.FC<HeaderDropdownProps> = ({
+  overlayClassName: cls,
+  ...restProps
+}) => (
+  <Dropdown
+    getPopupContainer={(trigger) =>( trigger.parentNode as HTMLElement)}
+    overlayClassName={cls}
+    {...restProps}
+  />
+);
+{{/Antd}}
+
+interface LocalData {
+    lang: string,
+    label?: string,
+    icon?: string,
+    title?: string,
+}
+
+interface SelectLangProps {
+  globalIconClassName?: string,
+  postLocalesData?: (locales: LocalData[]) => LocalData[],
+  onItemClick?: (params:ClickParam) => void,
+}
+
+const transformArrayToObject = (allLangUIConfig:LocalData[])=>{
+  return allLangUIConfig.reduce((obj, item) => {
+    if(!item.lang){
+      return obj;
+    }
+
+    return {
+      ...obj,
+      [item.lang]: item,
+    };
+  }, {});
+}
+
+export const SelectLang: React.FC<SelectLangProps> = (props) => {
+  {{#ShowSelectLang}}
+  const { globalIconClassName, postLocalesData, onItemClick, ...restProps } = props;
+  const selectedLang = getLocale();
+
+  const changeLang = ({ key }: ClickParam): void => setLocale(key);
+
+  const defaultLangUConfig = [
+    {
+      lang: 'zh-CN',
+      label: '简体中文',
+      icon: '🇨🇳',
+      title: '语言',
+    },
+    {
+      lang: 'zh-TW',
+      label: '繁体中文',
+      icon: '🇭🇰',
+      title: '語言',
+    },
+    {
+      lang: 'en-US',
+      label: 'English',
+      icon: '🇺🇸',
+      title: 'Language',
+    },
+    {
+      lang: 'pt-BR',
+      label: 'Português',
+      icon: '🇧🇷',
+      title: 'Idiomas',
+    }
+  ]
+
+  const allLangUIConfig = transformArrayToObject(postLocalesData ?  postLocalesData(defaultLangUConfig): defaultLangUConfig);
+
+  const handleClick = onItemClick ? (params)=> onItemClick(params): changeLang;
+
+  const menuItemStyle = { minWidth: '160px' }
+  const langMenu = (
+    <Menu 
+      selectedKeys={[selectedLang]} onClick={handleClick}
+    >
+     {{#LocaleList}}
+        <Menu.Item key={'{{locale}}'} style={menuItemStyle}>
+          <span role='img' aria-label={allLangUIConfig['{{locale}}']?.label  || '{{locale}}'}>
+            {allLangUIConfig['{{locale}}']?.icon || "🌐"}
+          </span>{' '}
+          {allLangUIConfig['{{locale}}']?.label || '{{locale}}'}
+        </Menu.Item>
+      {{/LocaleList}}
+    </Menu>
+  );
+
+  const style = {
+    verticalAlign: 'top',
+    cursor: 'pointer',
+    padding: '0 12px',
+  }
+
+  return (
+    <HeaderDropdown overlay={langMenu} placement='bottomRight' {...restProps}>
+      <span 
+        className={globalIconClassName} 
+        style={style}>
+        <GlobalOutlined title={allLangUIConfig[selectedLang]?.title} />
+      </span>
+    </HeaderDropdown>
+  );
+  {{/ShowSelectLang}}
+  return <></>
+};


### PR DESCRIPTION
locale 插件支持导出 <Selectlang/> 组件

选择语言的展示组件。可以通过开启 locale 插件，从 umi 中获取该组件。只有当项目依赖 antd, 同时项目 /locales 文件夹下有超过两个语言文件时才会显示。可配置的属性有：

- langUIConfig, 默认包含 "简体中文" 、"繁体中文"、 "英文" 三种语言配置,当需要展示其他语言时，可以通过配置 langUIConfig 来扩展，格式如下所示。
- globalIconClassName, 全球图标的样式。
- <[Dropdown/](https://ant.design/components/dropdown-cn/#API)> 的所有 API。

```tsx
import { SelectLang } from 'umi';

<SelectLang
  langUIConfig={[{
    lang: 'nl-NL', // 语言的 key 与 antd & locales 下的文件名保持一致
    label: 'Nederlands', // 下拉菜单中展示的语言名
    icon: '🇳🇱', // 下拉菜单中展示的 icon （一般为国旗
    title: 'Taal', // 鼠标浮上全球图标时展示的文案（一般为“语言”这个词的各种翻译
  }]}
>
```