### PR TITLE
fix: change connect.ts name

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
       '^react-dom$': require.resolve('react-dom'),
     });
   },
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'd.ts'],
 };

--- a/packages/plugin-dva/src/index.ts
+++ b/packages/plugin-dva/src/index.ts
@@ -146,7 +146,7 @@ app.model({ namespace: '${basename(path, extname(path))}', ...(require('${path}'
 
       const connectTpl = readFileSync(join(__dirname, 'connect.tpl'), 'utf-8');
       api.writeTmpFile({
-        path: 'plugin-dva/connect.ts',
+        path: 'plugin-dva/connect.d.ts',
         content: Mustache.render(connectTpl, {
           dvaHeadExport: models
             .map(path => {


### PR DESCRIPTION
多个 export * from model  会导致 ts 的同名冲突，
改成d.ts个可以使用 skipLibCheck 跳过检查，不影响目前的功能。