### PR TITLE
feat:Add direction support to plugin-local [URGENT!!!]

### DIFF
--- a/packages/plugin-locale/src/templates/locale.tpl
+++ b/packages/plugin-locale/src/templates/locale.tpl
@@ -10,7 +10,7 @@ import moment from 'moment';
 import 'moment/locale/{{.}}';
 {{/MomentLocales}}
 {{/MomentLocales.length}}
-import { RawIntlProvider, getLocale, setIntl, getIntl, localeInfo } from './localeExports';
+import { RawIntlProvider, getLocale, getDirection , setIntl, getIntl, localeInfo } from './localeExports';
 
 // @ts-ignore
 export const event = new EventEmitter();

--- a/packages/plugin-locale/src/templates/locale.tpl
+++ b/packages/plugin-locale/src/templates/locale.tpl
@@ -60,11 +60,14 @@ export const _LocaleContainer = (props:any) => {
     ...require('{{{.}}}').default,
     {{/DefaultAntdLocales}}
   }
+  const direcition = getDirection();
+  
   return (
-    <ConfigProvider locale={localeInfo[locale]?.antd || defaultAntdLocale}>
+    <ConfigProvider  direction={direcition} locale={localeInfo[locale]?.antd || defaultAntdLocale}>
       <RawIntlProvider value={intl}>{props.children}</RawIntlProvider>
     </ConfigProvider>
   )
+
   {{/Antd}}
 
   return <RawIntlProvider value={intl}>{props.children}</RawIntlProvider>;

--- a/packages/plugin-locale/src/templates/localeExports.tpl
+++ b/packages/plugin-locale/src/templates/localeExports.tpl
@@ -134,6 +134,19 @@ export const getLocale = () => {
   return lang || browserLang || {{{DefaultLocale}}};
 };
 
+
+/**
+ * 获取当前选择的方向
+ * @returns string
+ */
+export const getDirection = () => {
+  const lang = getLocale();
+  // array with all prefixs for rtl langueges ex: ar-EG , he-IL
+  const rtlLangs = ['he', 'ar', 'fa', 'ku']
+  const direction =  rtlLangs.filter(lng => lang.startsWith(lng)).length ? 'rtl' : 'ltr';
+  return direction;
+};
+
 /**
  * 切换语言
  * @param lang 语言的 key


### PR DESCRIPTION
Add direction support to plugin-local, so the direction attribute can be determined and
passed to ConfigProvider, the main purpose behind this effort is to add RTL support
in ant design pro, issue #6599 in ant design pro repo