### PR TITLE
fix: the lastStateRef repeat setting

### DIFF
--- a/packages/plugin-model/src/utils/getUseModelContent.ts
+++ b/packages/plugin-model/src/utils/getUseModelContent.ts
@@ -30,15 +30,15 @@ export function useModel<T extends keyof Model<T>, U>(
   const [state, setState] = useState<RetState>(
     () => updaterRef.current ? updaterRef.current(dispatcher.data![namespace]) : dispatcher.data![namespace]
   );
-  const lastState = useRef<any>(state);
+  const stateRef = useRef<any>(state);
 
   useEffect(() => {
     const handler = (e: any) => {
       if(updater && updaterRef.current){
-        const ret = updaterRef.current(e);
-        if(!isEqual(ret, lastState.current)){
-          lastState.current = ret;
-          setState(ret);
+        const currentState = updaterRef.current(e);
+        const previousState = stateRef.current
+        if(!isEqual(currentState, previousState)){
+          setState(currentState);
         }
       } else {
         setState(e);


### PR DESCRIPTION
**问题原因**：

将 lastState 赋值给 useRef<any>(state)，就会让 lastState 和 state 同步数据，当 state 变化后 lastState 的值也会跟着变，然后在下面的第 3 行处又手动将当前的新值赋值给 lastState, 就会导致会不重新 render

``` ts
 1 if (!isEqual(ret, lastState.current)) {
 2 lastState.current = ret;
 3  setState(ret);
 4 }
```
PS:  这个地方为了代码可读性，更改了一下变量命名

issue refs: https://github.com/umijs/plugins/issues/215