### PR TITLE
feat: add plugin-access-layout

### DIFF
--- a/packages/plugin-access-layout/README.md
+++ b/packages/plugin-access-layout/README.md
@@ -1,0 +1,143 @@
+# @umijs/plugin-access-layout
+
+## 使用
+
+使用 npm:
+
+```bash
+$ npm install --save-dev @umijs/plugin-access-layout
+```
+
+或者使用 yarn:
+
+```bash
+$ yarn add @umijs/plugin-access-layout --dev
+```
+
+## 说明
+
+这个插件将 plugin-access 和 plugin-layout 插件的功能整合在一起，为了支持 Umi 的约定式用法，还有更多的动态设置方案。
+
+## 特性
+
+1、支持约定式和配置式 2、动态修改权限 3、动态使用菜单 4、支持运行时配置 Pro-Layout 5、支持页面级别配置 Pro-Layout 6、支持页面级权限 7、支持页面级修改权限 8、支持不使用 Pro-layout 9、兼容 Pro 旧项目的写法
+
+## 搭配其他插件
+
+1、配套 plugin-locale 使用，会默认开始国际化的菜单 2、配合 plugin-model 使用，可以使用 useModel('@@accessLayout') 3、配合 plugin-initial-state 使用，可以不指定权限判断数据
+
+## Config 配置
+
+```ts
+accessLayout: {
+  iconNames: ['smile'], // 约定式用法，需要将所有用到的 icon 名称写全，为了按需加载
+  useModel: true, // 声明是否搭配了 plugin-model 使用
+}
+```
+
+## 运行时配置
+
+```ts
+export const accessLayout = {
+  title: 'Runtime Demo',
+  // Pro-Layout 支持的所有配置
+};
+```
+
+## 页面级配置
+
+```ts
+useEffect(() => {
+  setLayoutConfig({
+    title: 'PageSetDemo',
+    // Pro-Layout 支持的所有配置
+  });
+}, []);
+```
+
+## 页面级别权限控制
+
+```ts
+import { useModel } from 'umi';
+const { access } = useModel('@@accessLayout');
+if (access.canAdmin) {
+  // canAdmin 在src/access 中定义
+  // 或者使用 setAccess 设置
+  console.log('access.canAdmin');
+}
+```
+
+## 页面级修改权限
+
+```tsx
+import { useModel } from 'umi';
+
+const IndexPage: FC<PageProps> = ({ index, dispatch }) => {
+  const { setAccess } = useModel('@@accessLayout');
+  return (
+    <div
+      className={styles.center}
+      onClick={() => setAccess({ canAdmin: false })}
+    >
+      点击操作权限
+    </div>
+  );
+};
+```
+
+## 扩展菜单配置
+
+可以指定部分页面不使用 layout
+
+```ts
+const menuData = [
+  {
+    path: '/login',
+    hideLayout: true,
+  },
+];
+```
+
+## 支持约定式路由用法
+
+```ts
+// src/layouts/index
+import { AccessLayout } from 'umi';
+
+const BasicLayout = props => {
+  // 这个数据可以是任意来源的，你可以在登录之后再去获取菜单数据
+  const serveMenuData = [
+    {
+      path: '/',
+      name: 'index',
+      icon: 'smile',
+    },
+    {
+      path: '/ListTableList',
+      name: 'list',
+      icon: 'heart',
+      access: 'canAdmin',
+    },
+    {
+      path: '/login',
+      hideLayout: true,
+    },
+  ];
+  // 这个数据会传递给 src/access.ts
+  // 搭配 plugin-initial-state 使用的话，这个可以不传
+  const initState = {
+    currentUser: {
+      access: 'admin',
+    },
+  };
+  return (
+    <AccessLayout
+      initState={initState}
+      menuData={serveMenuData}
+      {...props}
+    ></AccessLayout>
+  );
+};
+
+export default BasicLayout;
+```

--- a/packages/plugin-access-layout/package.json
+++ b/packages/plugin-access-layout/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@umijs/plugin-access-layout",
+  "version": "1.0.0-beta.1",
+  "description": "@umijs/plugin-access-layout",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/umijs/plugins"
+  },
+  "keywords": [
+    "umi"
+  ],
+  "authors": [
+    "xiaohuoni <4486276632@qq.com> (https://github.com/xiaohuoni)"
+  ],
+  "license": "MIT",
+  "bugs": "http://github.com/umijs/plugins/issues",
+  "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-access-layout#readme",
+  "peerDependencies": {
+    "umi": "3.x"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-access-layout/src/AccessLayout.tpl
+++ b/packages/plugin-access-layout/src/AccessLayout.tpl
@@ -1,0 +1,124 @@
+import React, { FC,useEffect } from 'react';
+import ProLayout, { MenuDataItem, BasicLayoutProps } from '@ant-design/pro-layout';
+{{#hasAccess}}
+import accessFactory from '@/access';
+{{/hasAccess}}
+// @ts-ignore
+import { traverseModifyRoutes } from '{{{ utilsPath }}}';
+import { transformRoute } from '@umijs/route-utils';
+{{#useModel}}
+import { Link, useIntl, IntlShape, useModel } from 'umi';
+{{/useModel}}
+{{#noModel}}
+import { Link, useIntl, IntlShape } from 'umi';
+{{/noModel}}
+import { WithExceptionOpChildren } from './components';
+{{{ importIcons }}}
+
+interface LayoutConfigProps {
+  locale?: boolean; // 是否使用 locale
+  iconNames?:string[];// 约定式的用法，用到的 icon 要提前在这里写明
+}
+interface AccessLayoutProps extends BasicLayoutProps {
+  menuData?: MenuDataItem[];
+  initState?: any;
+  useLocale?: boolean;
+  layoutConfig?: LayoutConfigProps;
+}
+// 运行时动态生成这个 Map
+// const IconMap = {
+//   smile: <SmileOutlined />,
+//   heart: <HeartOutlined />,
+// };
+const IconMap = {
+{{{ useIcons }}}
+};
+// 替换服务端数据中的icon
+const loopMenuItem = (menus: MenuDataItem[]): MenuDataItem[] =>
+  menus.map(({ icon, children, ...item }) => ({
+    ...item,
+    icon: icon && IconMap[icon as string],
+    children: children && loopMenuItem(children),
+  }));
+
+const style = {
+  height: '100vh',
+}
+const AccessLayout: FC<AccessLayoutProps> = ({ menuData: serveMenuData, location, children, initState = {}, useLocale = false, layoutConfig = {},route, ...other }) => {
+{{#useModel}}
+  const { layoutConfig: pageSetLayoutConfig } = useModel('@@accessLayout');
+{{/useModel}}
+  const { locale, ...otherConfig } = layoutConfig;
+  // 国际化插件并非默认启动
+  const intl = useIntl?.();
+  const { pathname } = location!;
+{{#hasAccess}}
+{{#useModel}}
+  // plugin-initial-state 未开启
+  const initialInfo = (useModel && useModel('@@initialState')) || {
+    initialState: undefined,
+    loading: false,
+    setInitialState: null,
+  };
+  const { access: layoutAccess, setAccess } = useModel('@@accessLayout');
+  const { initialState, loading, setInitialState } = initialInfo;
+{{/useModel}}
+{{#noModel}}
+const initialState = null;
+{{/noModel}}
+  const access = accessFactory(initState||initialState);
+  const accrssMenu = traverseModifyRoutes(serveMenuData||route?.routes, access);
+  const { menuData, breadcrumb } = transformRoute(accrssMenu, locale || useLocale, intl && intl.formatMessage, false);
+{{#useModel}}
+  useEffect(() => {
+    if (JSON.stringify(layoutAccess) !== JSON.stringify(access)) {
+      setAccess(access);
+      console.log('setAccess(access)')
+    }
+  }, [JSON.stringify(access)])
+{{/useModel}}
+{{/hasAccess}}
+{{#noAccess}}
+{{#useModel}}
+  const { access: layoutAccess } = useModel('@@accessLayout');
+  const accrssMenu = traverseModifyRoutes(serveMenuData||route?.routes, layoutAccess);
+   // @ts-ignore
+  const { menuData, breadcrumb } = transformRoute(accrssMenu, locale || useLocale, intl && intl.formatMessage, false);
+{{/useModel}}
+{{#noModel}}
+  // @ts-ignore
+  const { menuData, breadcrumb } = transformRoute(serveMenuData||route?.routes, locale || useLocale, intl && intl.formatMessage, false);
+{{/noModel}}
+{{/noAccess}}
+  const currentPathConfig = breadcrumb.get(pathname!);
+
+  if(currentPathConfig?.hideLayout){
+    return <>{children}</>
+  }
+  return <ProLayout
+    location={location}
+    menuItemRender={(menuItemProps, defaultDom) => {
+      if (menuItemProps.isUrl || menuItemProps.children || !menuItemProps.path) {
+        return defaultDom;
+      }
+      return <Link to={menuItemProps.path}>{defaultDom}</Link>;
+    }}
+    {...other}
+    {...otherConfig}
+{{#useModel}}
+    {...pageSetLayoutConfig}
+{{/useModel}}
+    menuDataRender={() => loopMenuItem(menuData as MenuDataItem[])}
+  >
+    <div
+      style={style}
+    >
+      <WithExceptionOpChildren currentPathConfig={currentPathConfig}>
+        {children}
+      </WithExceptionOpChildren>
+    </div>
+  </ProLayout>
+
+}
+
+export { AccessLayout };

--- a/packages/plugin-access-layout/src/LayoutContent.tpl
+++ b/packages/plugin-access-layout/src/LayoutContent.tpl
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ApplyPluginsType } from 'umi';
+import { plugin } from '../core/umiExports';
+import { AccessLayout } from './AccessLayout';
+
+export default (props) => {
+  const layoutConfig = plugin.applyPlugins({
+    key: 'accessLayout',
+    type: ApplyPluginsType.modify,
+    initialValue: {},
+  }) || {};
+  return React.createElement(AccessLayout, {
+    layoutConfig,
+    ...props
+  })
+}

--- a/packages/plugin-access-layout/src/LayoutModel.tpl
+++ b/packages/plugin-access-layout/src/LayoutModel.tpl
@@ -1,0 +1,7 @@
+import { useState } from 'react';
+
+export default () => {
+  const [access, setAccess] = useState<any>({});
+  const [layoutConfig, setLayoutConfig] = useState<any>({});
+  return { access, setAccess, layoutConfig, setLayoutConfig };
+}

--- a/packages/plugin-access-layout/src/components.tpl
+++ b/packages/plugin-access-layout/src/components.tpl
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Result, Button } from 'antd';
+import { history } from 'umi';
+
+function backToHome() {
+  history.push('/');
+}
+
+const Exception404 = () => (
+  <Result
+    status="404"
+    title="404"
+    subTitle="抱歉，你访问的页面不存在"
+    extra={
+      <Button type="primary" onClick={backToHome}>
+        返回首页
+      </Button>
+    }
+  />
+);
+
+const Exception500 = () => (
+  <Result
+    status="500"
+    title="500"
+    subTitle="抱歉，服务器出错了"
+    extra={
+      <Button type="primary" onClick={backToHome}>
+        返回首页
+      </Button>
+    }
+  />
+);
+
+const Exception403 = () => (
+  <Result
+    status="403"
+    title="403"
+    subTitle="抱歉，你无权访问该页面"
+    extra={
+      <Button type="primary" onClick={backToHome}>
+        返回首页
+      </Button>
+    }
+  />
+);
+
+/**
+ * 异常路由处理组件
+ * - 无权限
+ * - 404
+ */
+const WithExceptionOpChildren: React.FC<{
+  currentPathConfig?: any;
+  children: any;
+}> = props => {
+  const { children, currentPathConfig } = props;
+  if (!currentPathConfig) {
+    return <Exception404 />;
+  }
+  if (currentPathConfig.unaccessible) {
+    return <Exception403 />;
+  }
+  return children;
+};
+
+export { Exception404, Exception403, Exception500, WithExceptionOpChildren };

--- a/packages/plugin-access-layout/src/docs/README.md
+++ b/packages/plugin-access-layout/src/docs/README.md
@@ -1,0 +1,19 @@
+# @umijs/plugin-access-layout
+
+> @umijs/plugin-access-layout.
+
+See our website [@umijs/plugin-access-layout](https://umijs.org/plugins/plugin-access-layout) for more information.
+
+## Install
+
+Using npm:
+
+```bash
+$ npm install --save-dev @umijs/plugin-access-layout
+```
+
+or using yarn:
+
+```bash
+$ yarn add @umijs/plugin-access-layout --dev
+```

--- a/packages/plugin-access-layout/src/index.ts
+++ b/packages/plugin-access-layout/src/index.ts
@@ -1,0 +1,170 @@
+import { IApi, utils } from 'umi';
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { checkIfHasDefaultExporting } from './utils';
+
+const { Mustache, lodash, winPath } = utils;
+
+const DIR_NAME = 'access-layout';
+const MODEL_NAME = 'AccessLayout';
+const RELATIVE_MODEL = join(DIR_NAME, MODEL_NAME);
+
+function toHump(name: string) {
+  return name.replace(/\-(\w)/g, function(all, letter) {
+    return letter.toUpperCase();
+  });
+}
+
+function formatter(data: any, iconNames: string[]): any[] {
+  if (!Array.isArray(data)) {
+    return iconNames.map((icon: any) => {
+      const v4IconName = toHump(icon.replace(icon[0], icon[0].toUpperCase()));
+      return {
+        v4IconName: v4IconName === icon ? v4IconName : `${v4IconName}Outlined`,
+        name: icon,
+      };
+    });
+  }
+  let icons: any[] = [];
+  (data || []).forEach((item = { path: '/' }) => {
+    if (item.icon) {
+      const { icon } = item;
+      const v4IconName = toHump(icon.replace(icon[0], icon[0].toUpperCase()));
+      icons.push({
+        v4IconName: v4IconName === icon ? v4IconName : `${v4IconName}Outlined`,
+        name: icon,
+      });
+    }
+    const items = item.routes || item.children;
+    if (items) {
+      icons = icons.concat(formatter(items, []));
+    }
+  });
+
+  return icons;
+}
+
+export default (api: IApi) => {
+  if (!api.userConfig.accessLayout) return;
+  const accessFilePath = api.utils.winPath(
+    join(api.paths.absSrcPath!, 'access'),
+  );
+  const hasAccess = checkIfHasDefaultExporting(accessFilePath);
+  api.describe({
+    key: 'accessLayout',
+    config: {
+      default: {},
+      schema(joi) {
+        return joi.object({
+          iconNames: joi.array(),
+          useModel: joi.boolean(),
+        });
+      },
+      onChange: api.ConfigChangeType.regenerateTmpFiles,
+    },
+  });
+
+  // 没有 routes 配置，表示使用约定式路由
+  const isConventionRouting = !api.userConfig.routes;
+  // 约定式的这个需要明确写明，配置式的可选
+  const { iconNames, useModel } = api.userConfig.accessLayout;
+  if (isConventionRouting && !iconNames) {
+    api.logger.error('未在配置中写明使用到的icon，将会导致菜单栏icon无法显示!');
+  }
+  const icons = formatter(api.userConfig.routes, iconNames);
+  api.onGenerateFiles(() => {
+    const accessLayoutTpl = readFileSync(
+      join(__dirname, 'AccessLayout.tpl'),
+      'utf-8',
+    );
+    const importIcons = icons.map(
+      ({ v4IconName }) =>
+        `import ${v4IconName} from '@ant-design/icons/${v4IconName}'`,
+    );
+    const useIcons = icons.map(
+      ({ name, v4IconName }) => `${name}:<${v4IconName} />`,
+    );
+    const utilsPath = winPath(
+      join(__dirname, '..', 'lib', 'utils', 'runtimeUtil'),
+    );
+    api.writeTmpFile({
+      path: join(DIR_NAME, 'AccessLayout.tsx'),
+      content: Mustache.render(accessLayoutTpl, {
+        importIcons: importIcons.join(';\n'),
+        utilsPath,
+        useModel,
+        hasAccess,
+        noAccess: !hasAccess,
+        noModel: !useModel,
+        useIcons: useIcons.join(',\n'),
+      }),
+    });
+    const componentsTpl = readFileSync(
+      join(__dirname, 'components.tpl'),
+      'utf-8',
+    );
+    api.writeTmpFile({
+      path: join(DIR_NAME, 'components.tsx'),
+      content: componentsTpl,
+    });
+    const layoutContentTpl = readFileSync(
+      join(__dirname, 'LayoutContent.tpl'),
+      'utf-8',
+    );
+    api.writeTmpFile({
+      path: join(DIR_NAME, 'LayoutContent.tsx'),
+      content: layoutContentTpl,
+    });
+    if (useModel) {
+      const layoutModelTpl = readFileSync(
+        join(__dirname, 'LayoutModel.tpl'),
+        'utf-8',
+      );
+      api.writeTmpFile({
+        path: join(DIR_NAME, 'LayoutModel.tsx'),
+        content: layoutModelTpl,
+      });
+    }
+  });
+
+  api.modifyDefaultConfig(config => {
+    // @ts-ignore
+    config.title = false;
+    return config;
+  });
+
+  if (useModel) {
+    api.register({
+      key: 'addExtraModels',
+      fn: () => [
+        {
+          absPath: winPath(
+            join(api.paths.absTmpPath!, DIR_NAME, 'LayoutModel.ts'),
+          ),
+          namespace: '@@accessLayout',
+        },
+      ],
+    });
+  }
+
+  // 使用配置式
+  if (!isConventionRouting) {
+    // 注册runtime配置
+    api.addRuntimePluginKey(() => 'accessLayout');
+    api.modifyRoutes(routes => [
+      {
+        path: '/',
+        component: winPath(
+          join(api.paths.absTmpPath || '', DIR_NAME, 'LayoutContent.tsx'),
+        ),
+        routes,
+      },
+    ]);
+  }
+  api.addUmiExports(() => [
+    {
+      exportAll: true,
+      source: `../${RELATIVE_MODEL}`,
+    },
+  ]);
+};

--- a/packages/plugin-access-layout/src/utils/index.ts
+++ b/packages/plugin-access-layout/src/utils/index.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+
+export function getScriptPath(filepath: string): string {
+  let realFilePath: string = '';
+  if (fs.existsSync(`${filepath}.ts`)) {
+    realFilePath = `${filepath}.ts`;
+  } else if (fs.existsSync(`${filepath}.js`)) {
+    realFilePath = `${filepath}.js`;
+  }
+  return realFilePath;
+}
+
+export function checkIfHasDefaultExporting(filepath: string): boolean {
+  const scriptPath = getScriptPath(filepath);
+  if (!scriptPath) {
+    return false;
+  }
+
+  const fileContent = fs.readFileSync(scriptPath, 'utf8');
+  const validationRegExp = /(export\s*default)|(exports\.default)|(module.exports[\s\S]*default)|(module.exports[\s\n]*=)/m;
+
+  return validationRegExp.test(fileContent);
+}

--- a/packages/plugin-access-layout/src/utils/runtimeUtil.ts
+++ b/packages/plugin-access-layout/src/utils/runtimeUtil.ts
@@ -1,0 +1,70 @@
+// This file is for runtime, not the compile time.
+import { IRoute } from 'umi';
+
+type Routes = IRoute[];
+
+export function traverseModifyRoutes(routes: Routes, access: any) {
+  const resultRoutes: Routes = []
+    .concat(routes as any)
+    .map((resultRoute: IRoute) => {
+      const { routes } = resultRoute;
+      return {
+        ...resultRoute,
+        // return new route to routes.
+        routes: routes ? routes.map((route: any) => ({ ...route })) : routes,
+      };
+    });
+  const notHandledRoutes: Routes = [];
+
+  notHandledRoutes.push(...resultRoutes);
+
+  for (let i = 0; i < notHandledRoutes.length; i++) {
+    const currentRoute = notHandledRoutes[i];
+    let currentRouteAccessible =
+      typeof currentRoute.unaccessible === 'boolean'
+        ? !currentRoute.unaccessible
+        : true;
+    if (currentRoute && currentRoute.access) {
+      if (typeof currentRoute.access !== 'string') {
+        throw new Error(
+          '[plugin-access]: "access" field set in "' +
+            currentRoute.path +
+            '" route should be a string.',
+        );
+      }
+      const accessProp = access[currentRoute.access];
+      if (typeof accessProp === 'function') {
+        currentRouteAccessible = accessProp(currentRoute);
+      } else if (typeof accessProp === 'boolean') {
+        currentRouteAccessible = accessProp;
+      }
+      currentRoute.unaccessible = !currentRouteAccessible;
+    }
+
+    if (currentRoute.routes || currentRoute.childRoutes) {
+      const childRoutes: Routes =
+        currentRoute.routes || currentRoute.childRoutes;
+      if (!Array.isArray(childRoutes)) {
+        continue;
+      }
+      childRoutes.forEach(childRoute => {
+        childRoute.unaccessible = !currentRouteAccessible;
+      }); // Default inherit from parent route
+      notHandledRoutes.push(...childRoutes);
+    }
+  }
+
+  // Make parent route unaccessible if child routes exist and all of child routes are unaccessible
+  for (let i = 0; i < notHandledRoutes.length; i++) {
+    const currentRoute = notHandledRoutes[i];
+    const childRoutes: Routes = currentRoute.routes || currentRoute.childRoutes;
+    const isAllChildRoutesUnaccessible =
+      Array.isArray(childRoutes) &&
+      childRoutes.every(route => route.unaccessible);
+    if (!currentRoute.unaccessible && isAllChildRoutesUnaccessible) {
+      currentRoute.unaccessible = true;
+    }
+  }
+
+  return resultRoutes;
+}


### PR DESCRIPTION
> 根据我上一次提到的方案，整合实现为 Umi@3 的插件。简单的试用了一下，发现几乎可以满足所有的需求，而且在我看来应该是理解成本最低的方案。

# @umijs/plugin-access-layout

## 使用

使用 npm:

```bash
$ npm install --save-dev @umijs/plugin-access-layout
```

或者使用 yarn:

```bash
$ yarn add @umijs/plugin-access-layout --dev
```

## 说明

这个插件将 plugin-access 和 plugin-layout 插件的功能整合在一起，为了支持 Umi 的约定式用法，还有更多的动态设置方案。

## 特性

1、支持约定式和配置式

2、动态修改权限

3、动态使用菜单

4、支持运行时配置 Pro-Layout

5、支持页面级别配置 Pro-Layout

6、支持页面级权限

7、支持页面级修改权限

8、支持不使用 Pro-layout

9、兼容 Pro 旧项目的写法

## 搭配其他插件

1、配套 plugin-locale 使用，会默认开始国际化的菜单

2、配合 plugin-model 使用，可以使用 useModel('@@accessLayout')

3、配合 plugin-initial-state 使用，可以不指定权限判断数据

## Config 配置

```ts
accessLayout: {
  iconNames: ['smile'], // 约定式用法，需要将所有用到的 icon 名称写全，为了按需加载
  useModel: true, // 声明是否搭配了 plugin-model 使用
}
```

## 运行时配置

```ts
export const accessLayout = {
  title: "Runtime Demo",
  // Pro-Layout 支持的所有配置
}
```

## 页面级配置

```ts
  useEffect(() => {
    setLayoutConfig({
      title: 'PageSetDemo',
      // Pro-Layout 支持的所有配置
    })
  }, []);
```


## 页面级别权限控制

```ts
import { useModel } from 'umi';
const { access } = useModel("@@accessLayout");
if (access.canAdmin) {
  // canAdmin 在src/access 中定义
  // 或者使用 setAccess 设置
  console.log('access.canAdmin')
}
```

## 页面级修改权限

```tsx
import { useModel } from 'umi';

const IndexPage: FC<PageProps> = ({ index, dispatch }) => {
  const { setAccess } = useModel("@@accessLayout");
  return (
    <div className={styles.center} onClick={()=>setAccess({canAdmin:false})}>
      点击操作权限
    </div>
  );
};

```

## 扩展菜单配置

可以指定部分页面不使用 layout

```ts
 const menuData = [
    {
      path: '/login',
      hideLayout:true
    },
  ];
```

## 支持约定式路由用法

```ts
// src/layouts/index
import { AccessLayout } from 'umi';

const BasicLayout = (props) => {
  // 这个数据可以是任意来源的，你可以在登录之后再去获取菜单数据
  const serveMenuData = [
    {
      path: '/',
      name: 'index',
      icon: 'smile',
    },
    {
      path: '/ListTableList',
      name: 'list',
      icon: 'heart',
      access: 'canAdmin'
    },
    {
      path: '/login',
      hideLayout:true
    },
  ];
  // 这个数据会传递给 src/access.ts
  // 搭配 plugin-initial-state 使用的话，这个可以不传
  const initState = {
        currentUser: {
          access: 'admin'
        }
      };
  return (
    <AccessLayout
      initState={initState}
      menuData={serveMenuData}
      {...props}
    >
    </AccessLayout>
  );
};

export default BasicLayout;
```
