### PR TITLE
fix: isValidModel model is react component

### DIFF
--- a/packages/plugin-dva/src/getModels/isValidModel.ts
+++ b/packages/plugin-dva/src/getModels/isValidModel.ts
@@ -34,6 +34,7 @@ export function isValidModel({ content }: { content: string }) {
   const ast = parser.parse(content, {
     sourceType: 'module',
     plugins: [
+      'jsx',
       'typescript',
       'classProperties',
       'dynamicImport',


### PR DESCRIPTION
当 model 只是一个普通的组件时，应该被正确编译。
 
Close: https://github.com/umijs/umi/issues/4780