### PR TITLE
feat: support ConfigProcider

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -75,7 +75,7 @@ export default (api: IApi) => {
         api.writeTmpFile({
           path: 'plugin-antd/runtime.tsx',
           content: Mustache.render(runtimeTpl, {
-            config: JSON.stringify(opts?.config),
+            config: JSON.stringify(otherConfig),
           }),
         });
       },

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -84,5 +84,6 @@ export default (api: IApi) => {
     api.addRuntimePlugin(() => [
       join(api.paths.absTmpPath!, 'plugin-antd/runtime.tsx'),
     ]);
+    api.addRuntimePluginKey(() => ['antd']);
   }
 };

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -1,9 +1,14 @@
-import { dirname } from 'path';
-import { IApi } from 'umi';
+import { dirname, join } from 'path';
+import { readFileSync } from 'fs';
+import { IApi, utils } from 'umi';
+import { ConfigProviderProps } from 'antd/es/config-provider';
+
+const { Mustache } = utils;
 
 interface IAntdOpts {
   dark?: boolean;
   compact?: boolean;
+  config?: ConfigProviderProps;
 }
 
 export default (api: IApi) => {
@@ -13,6 +18,7 @@ export default (api: IApi) => {
         return joi.object({
           dark: joi.boolean(),
           compact: joi.boolean(),
+          config: joi.object(),
         });
       },
     },
@@ -52,4 +58,31 @@ export default (api: IApi) => {
       path: dirname(require.resolve('antd-mobile/package.json')),
     },
   ]);
+  if (opts?.config) {
+    const { locale, ...otherConfig } = opts?.config;
+    if (locale) {
+      api.logger.warn(
+        'Invalid locale configuration in antd.config, please use plug-in @umijs/plugin-locale',
+      );
+    }
+    api.onGenerateFiles({
+      fn() {
+        // runtime.tsx
+        const runtimeTpl = readFileSync(
+          join(__dirname, 'runtime.tpl'),
+          'utf-8',
+        );
+        api.writeTmpFile({
+          path: 'plugin-antd/runtime.tsx',
+          content: Mustache.render(runtimeTpl, {
+            config: JSON.stringify(opts?.config),
+          }),
+        });
+      },
+    });
+    // Runtime Plugin
+    api.addRuntimePlugin(() => [
+      join(api.paths.absTmpPath!, 'plugin-antd/runtime.tsx'),
+    ]);
+  }
 };

--- a/packages/plugin-antd/src/runtime.tpl
+++ b/packages/plugin-antd/src/runtime.tpl
@@ -1,6 +1,18 @@
 import React from 'react';
 import { ConfigProvider } from 'antd';
+import { ApplyPluginsType } from 'umi';
+import { plugin } from '../core/umiExports';
 
 export function rootContainer(container) {
-  return React.createElement(ConfigProvider, {{{ config }}}, container);
+  const { locale, ...runtimeAntd } = plugin.applyPlugins({
+    key: 'antd',
+    type: ApplyPluginsType.modify,
+    initialValue: {},
+  });
+  if (locale) {
+    console.warn(
+      'Invalid locale configuration in runtime.antd.config, please use plug-in @umijs/plugin-locale',
+    );
+  }
+  return React.createElement(ConfigProvider, {...{{{ config }}},...runtimeAntd}, container);
 }

--- a/packages/plugin-antd/src/runtime.tpl
+++ b/packages/plugin-antd/src/runtime.tpl
@@ -1,0 +1,6 @@
+import React from 'react';
+import { ConfigProvider } from 'antd';
+
+export function rootContainer(container) {
+  return React.createElement(ConfigProvider, {{{ config }}}, container);
+}


### PR DESCRIPTION
增加配置 config，详细配置请查看 https://ant.design/components/config-provider-cn/

（合并后再添加文档）

```
antd:{
    config:ConfigProviderProps
}
```

注意：locale 配置无效，会提示用户使用 @umijs/plugin-locale
Close: https://github.com/ant-design/ant-design-pro/issues/6742