### PR TITLE
feat(layout): 支持在页面中手动通过 api 隐藏显示 layout 相关内容

### DIFF
--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -9,6 +9,14 @@ import {
   setLocale,
   Access,
   useAccess,
+  hideMenu,
+  showMenu,
+  hideNav,
+  showNav,
+  hideFooter,
+  showFooter,
+  hideLayout,
+  showLayout,
 } from 'umi';
 import { Table } from 'antd';
 import styles from './index.css';
@@ -80,6 +88,22 @@ export default connect(state => {
         >
           <button type="button">Update Article</button>
         </Access>
+      </div>
+      <div>
+        <button onClick={() => hideMenu()}>隐藏侧边栏</button>
+        <button onClick={() => showMenu()}>展示侧边栏</button>
+      </div>
+      <div>
+        <button onClick={() => hideNav()}>隐藏导航</button>
+        <button onClick={() => showNav()}>展示导航</button>
+      </div>
+      <div>
+        <button onClick={() => hideFooter()}>隐藏 footer</button>
+        <button onClick={() => showFooter()}>展示 footer</button>
+      </div>
+      <div>
+        <button onClick={() => hideLayout()}>隐藏 layout</button>
+        <button onClick={() => showLayout()}>展示 layout</button>
       </div>
     </div>
   );

--- a/packages/plugin-layout/src/index.ts
+++ b/packages/plugin-layout/src/index.ts
@@ -141,6 +141,11 @@ export default (api: IApi) => {
       path: join(DIR_NAME, 'runtime.tsx'),
       content: readFileSync(join(__dirname, 'runtime.tsx.tpl'), 'utf-8'),
     });
+
+    api.writeTmpFile({
+      path: join(DIR_NAME, 'messenger.ts'),
+      content: readFileSync(join(__dirname, 'messenger.ts.tpl'), 'utf-8'),
+    });
   });
   api.modifyRoutes(routes => {
     return [
@@ -155,4 +160,11 @@ export default (api: IApi) => {
   });
 
   api.addRuntimePlugin(() => ['@@/plugin-layout/runtime.tsx']);
+
+  api.addUmiExports(() => {
+    return {
+      exportAll: true,
+      source: `../plugin-layout/messenger`,
+    };
+  });
 };

--- a/packages/plugin-layout/src/layout/effects.ts
+++ b/packages/plugin-layout/src/layout/effects.ts
@@ -1,0 +1,64 @@
+/**
+ * 注册部分布局隐藏/显示的 listener，用于监听用户侧触发的切换部分布局是否显示的事件
+ * @param callback
+ */
+function registerToggleListener(
+  eventType: string,
+  callback: (display: boolean) => void,
+) {
+  function toggleDisplayListener(event: Event) {
+    callback((event as CustomEvent).detail.visible);
+  }
+
+  window.addEventListener(eventType, toggleDisplayListener);
+
+  return () => window.removeEventListener(eventType, toggleDisplayListener);
+}
+
+/**
+ * 注册侧边栏是否显示的事件
+ * @param callback
+ */
+export function registerSideMenuToggleListener(
+  callback: (display: boolean) => void,
+) {
+  const eventType = 'plugin-layout: toggle-sideMenu';
+
+  return registerToggleListener(eventType, callback);
+}
+
+/**
+ * 注册导航是否显示的事件
+ * @param callback
+ */
+export function registerNavToggleListener(
+  callback: (display: boolean) => void,
+) {
+  const eventType = 'plugin-layout: toggle-nav';
+
+  return registerToggleListener(eventType, callback);
+}
+
+/**
+ * 注册 footer 是否显示的事件
+ * @param callback
+ */
+export function registerFooterToggleListener(
+  callback: (display: boolean) => void,
+) {
+  const eventType = 'plugin-layout: toggle-footer';
+
+  return registerToggleListener(eventType, callback);
+}
+
+/**
+ * 注册 layout 是否显示的事件
+ * @param callback
+ */
+export function registerLayoutToggleListener(
+  callback: (display: boolean) => void,
+) {
+  const eventType = 'plugin-layout: toggle-layout';
+
+  return registerToggleListener(eventType, callback);
+}

--- a/packages/plugin-layout/src/layout/useLayoutConfig.ts
+++ b/packages/plugin-layout/src/layout/useLayoutConfig.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import { IRouteLayoutConfig } from '../types/interface';
+import {
+  registerSideMenuToggleListener,
+  registerNavToggleListener,
+  registerFooterToggleListener,
+  registerLayoutToggleListener,
+} from './effects';
+
+/**
+ * 获取用户手动调用相关 api 更改 layout 配置后的当前 layout 配置，以及与 pro-layout 对应的 layout render 配置
+ * @param currentLayoutConfig
+ */
+function useLayoutConfig(currentLayoutConfig: IRouteLayoutConfig | undefined) {
+  const [layoutConfig, setLayoutConfig] = useState(currentLayoutConfig);
+
+  useEffect(() => {
+    const unRegisterSideMenuToggleListener = registerSideMenuToggleListener(
+      visible =>
+        setLayoutConfig({
+          ...layoutConfig,
+          hideMenu: !visible,
+        }),
+    );
+
+    const unRegisterNavToggleListener = registerNavToggleListener(visible =>
+      setLayoutConfig({
+        ...layoutConfig,
+        hideNav: !visible,
+      }),
+    );
+
+    const unRegisterFooterToggleListener = registerFooterToggleListener(
+      visible =>
+        setLayoutConfig({
+          ...layoutConfig,
+          hideFooter: !visible,
+        }),
+    );
+
+    const unRegisterLayoutToggleListener = registerLayoutToggleListener(
+      visible =>
+        setLayoutConfig({
+          ...layoutConfig,
+          hideLayout: !visible,
+        }),
+    );
+    return () => {
+      unRegisterSideMenuToggleListener();
+      unRegisterNavToggleListener();
+      unRegisterFooterToggleListener();
+      unRegisterLayoutToggleListener();
+    };
+  }, []);
+
+  // 将当前 layout 配置转换成 pro-layout 组件对应的配置项
+  const layoutRender: any = {};
+  if (layoutConfig?.hideMenu) {
+    layoutRender.menuRender = false;
+  }
+  if (layoutConfig?.hideNav) {
+    layoutRender.headerRender = false;
+  }
+  if (layoutConfig?.hideLayout) {
+    layoutRender.pure = true;
+  }
+  if (layoutConfig?.hideFooter) {
+    layoutRender.footerRender = false;
+  }
+
+  return [layoutConfig, layoutRender];
+}
+
+export default useLayoutConfig;

--- a/packages/plugin-layout/src/messenger.ts.tpl
+++ b/packages/plugin-layout/src/messenger.ts.tpl
@@ -1,0 +1,40 @@
+function genCustomEventDetail(detail: any) {
+  return { detail };
+}
+
+function genCustomEvent(eventName: string, eventDetail: any) {
+  return new CustomEvent(eventName, genCustomEventDetail(eventDetail));
+}
+
+export function hideMenu() {
+   window.dispatchEvent(genCustomEvent('plugin-layout: toggle-sideMenu', { visible: false }));
+}
+
+export function showMenu() {
+   window.dispatchEvent(genCustomEvent('plugin-layout: toggle-sideMenu', { visible: true }));
+}
+
+
+export function hideNav() {
+  window.dispatchEvent(genCustomEvent('plugin-layout: toggle-nav', { visible: false }));
+}
+
+export function showNav() {
+  window.dispatchEvent(genCustomEvent('plugin-layout: toggle-nav', { visible: true }));
+}
+
+export function hideFooter() {
+  window.dispatchEvent(genCustomEvent('plugin-layout: toggle-footer', { visible: false }));
+}
+
+export function showFooter() {
+  window.dispatchEvent(genCustomEvent('plugin-layout: toggle-footer', { visible: true }));
+}
+
+export function hideLayout() {
+  window.dispatchEvent(genCustomEvent('plugin-layout: toggle-layout', { visible: false }));
+}
+
+export function showLayout() {
+  window.dispatchEvent(genCustomEvent('plugin-layout: toggle-layout', { visible: true }));
+}


### PR DESCRIPTION
```js
import {
  hideMenu,
  showMenu,
  hideNav,
  showNav,
  hideFooter,
  showFooter,
  hideLayout,
  showLayout } 
from 'umi';

export default () =>  <button onClick={() => hideMenu()}>隐藏侧边栏</button>
```
![image](https://user-images.githubusercontent.com/16719388/83629079-15732300-a5cc-11ea-880d-d61ffa57d6fc.png)
