### PR TITLE
fix: antd icons all in bundle when enable locale antd 

### DIFF
--- a/packages/plugin-helmet/fixtures/normal/src/app.js
+++ b/packages/plugin-helmet/fixtures/normal/src/app.js
@@ -1,0 +1,2 @@
+export function patchRoutes({ routes }) {
+}

--- a/packages/plugin-helmet/fixtures/ssr/src/app.js
+++ b/packages/plugin-helmet/fixtures/ssr/src/app.js
@@ -1,0 +1,2 @@
+export function patchRoutes({ routes }) {
+}

--- a/packages/plugin-locale/src/index.ts
+++ b/packages/plugin-locale/src/index.ts
@@ -194,7 +194,11 @@ export default (api: IApi) => {
         Antd: !!antd,
         LocaleList: localeList,
         ShowSelectLang: localeList.length > 1 && !!antd,
-        iconsPkgPath: winPath(require.resolve('@ant-design/icons')),
+        iconsPkgPath: winPath(
+          require.resolve(
+            `@ant-design/icons${api.config?.ssr ? '' : '/es/icons'}`,
+          ),
+        ),
         antdFiles: api.config?.ssr ? 'lib' : 'es',
       }),
     });

--- a/packages/plugin-locale/src/index.ts
+++ b/packages/plugin-locale/src/index.ts
@@ -195,9 +195,7 @@ export default (api: IApi) => {
         LocaleList: localeList,
         ShowSelectLang: localeList.length > 1 && !!antd,
         iconsPkgPath: winPath(
-          require.resolve(
-            `@ant-design/icons${api.config?.ssr ? '' : '/es/icons'}`,
-          ),
+          dirname(require.resolve('@ant-design/icons/package.json')),
         ),
         antdFiles: api.config?.ssr ? 'lib' : 'es',
       }),


### PR DESCRIPTION
处理 Close [umi 引入 ant.design全家桶时icons无法配置按需加载造成单包超过3M](https://github.com/umijs/umi/issues/4823) 引起的 icons 全量引入问题