### PR TITLE
feat: support serve menu

### DIFF
--- a/packages/plugin-access-layout/src/LayoutModel.tpl
+++ b/packages/plugin-access-layout/src/LayoutModel.tpl
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 export default () => {
   const [access, setAccess] = useState<any>({});
+  const [menu, setMenu] = useState<any>([]);
   const [layoutConfig, setLayoutConfig] = useState<any>({});
-  return { access, setAccess, layoutConfig, setLayoutConfig };
+  return { access, setAccess, layoutConfig, setLayoutConfig, menu, setMenu };
 }


### PR DESCRIPTION
相关 Issues https://github.com/ant-design/ant-design-pro/pull/6758
1、默认开启，通过配置关闭
2、useModel 配置，可以通过检测plugin-model 是否使用来自动开关
3、需要提供一个配置来控制，使用配置式路由，并且自定义 layout。即使用配置式不使用运行时的场景。便于更早的 pro 项目做升级。
4、动态菜单数据从 `useModel('@@accessLayout')` 中获取 menu 值，配置式使用的时候，需要留一个口子，在当前配置菜单的基础上修改。
可能是 除了 menu 再指定一个 menu 的修改函数，默认是直接替换。 如 props.renderMenuData
```
const { menu:serveMenu } = useModel('@@accessLayout');
const renderMenuData = props.renderMenuData || (a,b)=>b;
const localeMenu = props.menuData || props.routes;
const menu = renderMenuData(localeMenu,serveMenu);
```