### PR TITLE
fix: (plugin-preact) fix #192

### DIFF
--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -22,7 +22,8 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-preact#readme",
   "dependencies": {
-    "preact": "^10.3.4"
+    "preact": "^10.3.4",
+    "preact-compat": "^3.19.0"
   },
   "peerDependencies": {
     "umi": "3.x"


### PR DESCRIPTION
dependencies 中增加对 preact-compat 的依赖要求以修复 #192