### PR TITLE
Revert "fix: (plugin-preact) fix #192"

### DIFF
--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -22,8 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-preact#readme",
   "dependencies": {
-    "preact": "^10.3.4",
-    "preact-compat": "^3.19.0"
+    "preact": "^10.3.4"
   },
   "peerDependencies": {
     "umi": "3.x"


### PR DESCRIPTION
Reverts umijs/plugins#265

preact 10 开始不需要 preact-compat 的。