### PR TITLE
chore(qiankun): microApp auto setLoading

### DIFF
--- a/packages/plugin-qiankun/src/slave/lifecycles.ts
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts
@@ -71,6 +71,16 @@ export function genMount() {
     const historyOptions = normalizeHistory(props?.history, props?.base);
     setCreateHistoryOptions(historyOptions);
 
+    // 默认修改 loading
+    // 如果需要手动控制 loading
+    // 通过配置 app.ts，slave: { autoSetLanding: false }
+    if (
+      slaveRuntime?.autoSetLanding !== false &&
+      typeof props?.setLoading === 'function'
+    ) {
+      props.setLoading(false);
+    }
+
     defer.resolve();
     // 第一次 mount umi 会自动触发 render，非第一次 mount 则需手动触发
     if (hasMountedAtLeastOnce) {

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts
@@ -74,14 +74,17 @@ export function genMount() {
     // 默认修改 loading
     // 如果需要手动控制 loading
     // 通过配置 app.ts，slave: { autoSetLanding: false }
-    if (
-      slaveRuntime?.autoSetLanding !== false &&
-      typeof props?.setLoading === 'function'
-    ) {
-      props.setLoading(false);
-    }
-
-    defer.resolve();
+    const callback = () => {
+      if (
+        slaveRuntime?.autoSetLanding !== false &&
+        typeof props?.setLoading === 'function'
+      ) {
+        props.setLoading(false);
+      }
+    };
+    defer.resolve({
+      callback,
+    });
     // 第一次 mount umi 会自动触发 render，非第一次 mount 则需手动触发
     if (hasMountedAtLeastOnce) {
       render();


### PR DESCRIPTION
Close https://github.com/umijs/plugins/issues/233
ref: https://github.com/umijs/umi/pull/4979  ，单独发不受 umi callback 影响

子应用默认情况下，会自动处理 loading

如果子应用需要精准控制 loading，通过

```ts
// app.ts
export const qiankun = {
   slave: {
      // 关闭自动 loading
      autoSetLanding: false
   }
}
```

在子应用页面中，单独调用 `setLoading`

```tsx
// pages/Bar.tsx
import React from 'react';
import { useModel } from 'umi';

export default () => {
   const { setLoading } = useModel('@@qiankunStateFromMaster');
   React.useEffect(() => {
     setLoading(false);
   }, []);   
  ...
}
```