### PR TITLE
feat(qiankun): MicroApp support lifeCycles

### DIFF
--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -28,7 +28,7 @@ export function MicroApp(componentProps: Props) {
   const {
     masterHistoryType,
     apps = [],
-    lifeCycles,
+    lifeCycles: globalLifeCycles,
     ...globalSettings
   } = getMasterOptions() as any;
 
@@ -36,6 +36,7 @@ export function MicroApp(componentProps: Props) {
     name,
     settings: settingsFromProps = {},
     loader,
+    lifeCycles,
     ...propsFromParams
   } = componentProps;
 
@@ -63,6 +64,7 @@ export function MicroApp(componentProps: Props) {
         ...globalSettings,
         ...settingsFromProps,
       },
+      lifeCycles || globalLifeCycles,
     );
 
     return () => unmountMicroApp(microAppRef.current);

--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -6,6 +6,7 @@ import {
 } from 'qiankun';
 import React, { useEffect, useRef, useState } from 'react';
 import { useModel } from 'umi';
+import { mergeWith } from 'lodash';
 
 const qiankunStateForSlaveModelNamespace = '@@qiankunStateForSlave';
 
@@ -64,7 +65,12 @@ export function MicroApp(componentProps: Props) {
         ...globalSettings,
         ...settingsFromProps,
       },
-      lifeCycles || globalLifeCycles,
+      mergeWith(
+        {},
+        globalLifeCycles,
+        lifeCycles,
+        (v1, v2) => concat(v1 ?? [], v2 ?? [])
+      ),
     );
 
     return () => unmountMicroApp(microAppRef.current);


### PR DESCRIPTION
MicroApp 支持配置 lifeCycles

```jsx
<MicroApp 
  name="app1" 
  lifeCycles={{
    beforeLoad: (_, global) => { global._value= 123 }
  }}
/>
```