### PR TITLE
fix(access): 修复 access 的鉴权问题，其他 plugin 引用 access 插件的时候，读取的是 unAccessi…

### DIFF
--- a/packages/plugin-access-layout/src/components.tpl
+++ b/packages/plugin-access-layout/src/components.tpl
@@ -58,7 +58,7 @@ const WithExceptionOpChildren: React.FC<{
   if (!currentPathConfig) {
     return <Exception404 />;
   }
-  if (currentPathConfig.unaccessible) {
+  if (currentPathConfig.unAccessible) {
     return <Exception403 />;
   }
   return children;

--- a/packages/plugin-access-layout/src/utils/runtimeUtil.ts
+++ b/packages/plugin-access-layout/src/utils/runtimeUtil.ts
@@ -21,8 +21,8 @@ export function traverseModifyRoutes(routes: Routes, access: any) {
   for (let i = 0; i < notHandledRoutes.length; i++) {
     const currentRoute = notHandledRoutes[i];
     let currentRouteAccessible =
-      typeof currentRoute.unaccessible === 'boolean'
-        ? !currentRoute.unaccessible
+      typeof currentRoute.unAccessible === 'boolean'
+        ? !currentRoute.unAccessible
         : true;
     if (currentRoute && currentRoute.access) {
       if (typeof currentRoute.access !== 'string') {
@@ -38,7 +38,7 @@ export function traverseModifyRoutes(routes: Routes, access: any) {
       } else if (typeof accessProp === 'boolean') {
         currentRouteAccessible = accessProp;
       }
-      currentRoute.unaccessible = !currentRouteAccessible;
+      currentRoute.unAccessible = !currentRouteAccessible;
     }
 
     if (currentRoute.routes || currentRoute.childRoutes) {
@@ -48,21 +48,21 @@ export function traverseModifyRoutes(routes: Routes, access: any) {
         continue;
       }
       childRoutes.forEach(childRoute => {
-        childRoute.unaccessible = !currentRouteAccessible;
+        childRoute.unAccessible = !currentRouteAccessible;
       }); // Default inherit from parent route
       notHandledRoutes.push(...childRoutes);
     }
   }
 
-  // Make parent route unaccessible if child routes exist and all of child routes are unaccessible
+  // Make parent route unAccessible if child routes exist and all of child routes are unAccessible
   for (let i = 0; i < notHandledRoutes.length; i++) {
     const currentRoute = notHandledRoutes[i];
     const childRoutes: Routes = currentRoute.routes || currentRoute.childRoutes;
-    const isAllChildRoutesUnaccessible =
+    const isAllChildRoutesunAccessible =
       Array.isArray(childRoutes) &&
-      childRoutes.every(route => route.unaccessible);
-    if (!currentRoute.unaccessible && isAllChildRoutesUnaccessible) {
-      currentRoute.unaccessible = true;
+      childRoutes.every(route => route.unAccessible);
+    if (!currentRoute.unAccessible && isAllChildRoutesunAccessible) {
+      currentRoute.unAccessible = true;
     }
   }
 

--- a/packages/plugin-access/src/fixtures/normal/pages/index.tsx
+++ b/packages/plugin-access/src/fixtures/normal/pages/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const App = (props: any) => {
   return (
     <div>
-      <h1>unaccessible: {props.route.unaccessible.toString()}</h1>
+      <h1>unAccessible: {props.route.unAccessible.toString()}</h1>
     </div>
   );
 };

--- a/packages/plugin-access/src/index.test.ts
+++ b/packages/plugin-access/src/index.test.ts
@@ -10,5 +10,5 @@ test('normal', async () => {
   const cwd = join(fixtures, 'normal');
   await generateTmp({ cwd });
   const { container } = render({ cwd });
-  expect(container.innerHTML).toEqual('<div><h1>unaccessible: true</h1></div>');
+  expect(container.innerHTML).toEqual('<div><h1>unAccessible: true</h1></div>');
 });

--- a/packages/plugin-access/src/utils/runtimeUtil.ts
+++ b/packages/plugin-access/src/utils/runtimeUtil.ts
@@ -21,8 +21,8 @@ export function traverseModifyRoutes(routes: Routes, access: any) {
   for (let i = 0; i < notHandledRoutes.length; i++) {
     const currentRoute = notHandledRoutes[i];
     let currentRouteAccessible =
-      typeof currentRoute.unaccessible === 'boolean'
-        ? !currentRoute.unaccessible
+      typeof currentRoute.unAccessible === 'boolean'
+        ? !currentRoute.unAccessible
         : true;
     if (currentRoute && currentRoute.access) {
       if (typeof currentRoute.access !== 'string') {
@@ -38,7 +38,7 @@ export function traverseModifyRoutes(routes: Routes, access: any) {
       } else if (typeof accessProp === 'boolean') {
         currentRouteAccessible = accessProp;
       }
-      currentRoute.unaccessible = !currentRouteAccessible;
+      currentRoute.unAccessible = !currentRouteAccessible;
     }
 
     if (currentRoute.routes || currentRoute.childRoutes) {
@@ -48,21 +48,21 @@ export function traverseModifyRoutes(routes: Routes, access: any) {
         continue;
       }
       childRoutes.forEach(childRoute => {
-        childRoute.unaccessible = !currentRouteAccessible;
+        childRoute.unAccessible = !currentRouteAccessible;
       }); // Default inherit from parent route
       notHandledRoutes.push(...childRoutes);
     }
   }
 
-  // Make parent route unaccessible if child routes exist and all of child routes are unaccessible
+  // Make parent route unAccessible if child routes exist and all of child routes are unAccessible
   for (let i = 0; i < notHandledRoutes.length; i++) {
     const currentRoute = notHandledRoutes[i];
     const childRoutes: Routes = currentRoute.routes || currentRoute.childRoutes;
     const isAllChildRoutesUnaccessible =
       Array.isArray(childRoutes) &&
-      childRoutes.every(route => route.unaccessible);
-    if (!currentRoute.unaccessible && isAllChildRoutesUnaccessible) {
-      currentRoute.unaccessible = true;
+      childRoutes.every(route => route.unAccessible);
+    if (!currentRoute.unAccessible && isAllChildRoutesUnaccessible) {
+      currentRoute.unAccessible = true;
     }
   }
 

--- a/packages/plugin-access/src/utils/runtimeUtil.ts
+++ b/packages/plugin-access/src/utils/runtimeUtil.ts
@@ -58,10 +58,10 @@ export function traverseModifyRoutes(routes: Routes, access: any) {
   for (let i = 0; i < notHandledRoutes.length; i++) {
     const currentRoute = notHandledRoutes[i];
     const childRoutes: Routes = currentRoute.routes || currentRoute.childRoutes;
-    const isAllChildRoutesUnaccessible =
+    const isAllChildRoutesunAccessible =
       Array.isArray(childRoutes) &&
       childRoutes.every(route => route.unAccessible);
-    if (!currentRoute.unAccessible && isAllChildRoutesUnaccessible) {
+    if (!currentRoute.unAccessible && isAllChildRoutesunAccessible) {
       currentRoute.unAccessible = true;
     }
   }

--- a/packages/plugin-access/tests/utils/runtimeUtil.test.ts
+++ b/packages/plugin-access/tests/utils/runtimeUtil.test.ts
@@ -75,59 +75,59 @@ describe('TraverseModifyRoutes', () => {
       {
         path: '/homepage',
         access: 'canReadHomepage',
-        unaccessible: false,
+        unAccessible: false,
         routes: null,
       },
       {
         path: '/admin',
         access: 'canReadAdminPage',
-        unaccessible: true,
+        unAccessible: true,
         routes: [
           {
             path: '/adminList',
             access: 'canReadAdminList',
-            unaccessible: false,
+            unAccessible: false,
           },
           {
             path: '/adminDetail',
             access: 'canReadAdminDetail',
-            unaccessible: true,
+            unAccessible: true,
           },
         ],
       },
       {
         path: '/user',
         access: 'canReadUser',
-        unaccessible: false,
+        unAccessible: false,
         routes: [
           {
             path: '/userDetail',
             access: 'canReadUserDetail',
-            unaccessible: false,
+            unAccessible: false,
           },
         ],
       },
       {
         path: '/order',
         access: 'canReadOrder',
-        unaccessible: true,
+        unAccessible: true,
         routes: [
           {
             path: '/orderAudit',
             access: 'canReadOrderAudit',
-            unaccessible: true,
+            unAccessible: true,
           },
           {
             path: '/orderCancellation',
             access: 'canReadOrderCancellation',
-            unaccessible: true,
+            unAccessible: true,
           },
         ],
       },
       {
         path: '/about',
         access: 'canReadAbout',
-        unaccessible: false,
+        unAccessible: false,
       },
     ]);
   });

--- a/packages/plugin-layout/src/utils/getLayoutConfigFromRoute.ts
+++ b/packages/plugin-layout/src/utils/getLayoutConfigFromRoute.ts
@@ -59,7 +59,7 @@ function formatter(
   routes
     .filter(item => item && !item.path?.startsWith('http'))
     .map(route => {
-      const { layout, indexRoute, path = '', routes, unaccessible } = route;
+      const { layout, indexRoute, path = '', routes, unAccessible } = route;
 
       const execLayoutConfig = calcExecLayoutConfig(
         parentRouteLayoutConfig,
@@ -73,7 +73,7 @@ function formatter(
 
       LayoutConfig[`${prefix}${absolutePath}`] = {
         ...execLayoutConfig,
-        unAccessible: unaccessible || false,
+        unAccessible: unAccessible || false,
       };
 
       // 拼接 childrenRoutes, 处理存在 indexRoute 时的逻辑

--- a/packages/plugin-qiankun/CHANGELOG.md
+++ b/packages/plugin-qiankun/CHANGELOG.md
@@ -1,41 +1,25 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [2.5.1](https://github.com/umijs/plugins/compare/@umijs/plugin-qiankun@2.5.0...@umijs/plugin-qiankun@2.5.1) (2020-07-08)
 
-
 ### Bug Fixes
 
-* **qiankun:** concat not defined in MicroApp ([#298](https://github.com/umijs/plugins/issues/298)) ([2b65bf7](https://github.com/umijs/plugins/commit/2b65bf7d5af90565b4a77b17fb20602312129dfb))
-
-
-
-
+- **qiankun:** concat not defined in MicroApp ([#298](https://github.com/umijs/plugins/issues/298)) ([2b65bf7](https://github.com/umijs/plugins/commit/2b65bf7d5af90565b4a77b17fb20602312129dfb))
 
 # [2.5.0](https://github.com/umijs/plugins/compare/@umijs/plugin-qiankun@2.4.1...@umijs/plugin-qiankun@2.5.0) (2020-07-08)
 
-
 ### Features
 
-* **qiankun:** microApp auto setLoading ([#293](https://github.com/umijs/plugins/issues/293)) ([18c15f2](https://github.com/umijs/plugins/commit/18c15f2f041b7abffa826f665d6f88d9289479c8))
-* **qiankun:** MicroApp support lifeCycles ([#296](https://github.com/umijs/plugins/issues/296)) ([def736b](https://github.com/umijs/plugins/commit/def736b5830e7e41bdd4c24319e4c0c659aa751d))
-
-
-
-
+- **qiankun:** microApp auto setLoading ([#293](https://github.com/umijs/plugins/issues/293)) ([18c15f2](https://github.com/umijs/plugins/commit/18c15f2f041b7abffa826f665d6f88d9289479c8))
+- **qiankun:** MicroApp support lifeCycles ([#296](https://github.com/umijs/plugins/issues/296)) ([def736b](https://github.com/umijs/plugins/commit/def736b5830e7e41bdd4c24319e4c0c659aa751d))
 
 ## [2.4.1](https://github.com/umijs/plugins/compare/@umijs/plugin-qiankun@2.4.0...@umijs/plugin-qiankun@2.4.1) (2020-07-04)
 
-
 ### Bug Fixes
 
-* **qiankun:** 修复 mounting 期间更新操作丢失 & 短时间内连续更新会抛状态异常的问题 ([#289](https://github.com/umijs/plugins/issues/289)) ([2456e40](https://github.com/umijs/plugins/commit/2456e409e59baa2a04f3638b27f6448363892e51))
-
-
-
-
+- **qiankun:** 修复 mounting 期间更新操作丢失 & 短时间内连续更新会抛状态异常的问题 ([#289](https://github.com/umijs/plugins/issues/289)) ([2456e40](https://github.com/umijs/plugins/commit/2456e409e59baa2a04f3638b27f6448363892e51))
 
 # [2.4.0](https://github.com/umijs/plugins/compare/@umijs/plugin-qiankun@2.3.2...@umijs/plugin-qiankun@2.4.0) (2020-07-01)
 


### PR DESCRIPTION
**问题内容**: 修复 access 的鉴权问题
由于命名不规范，其他 plugin 引用 access 插件的时候，读取的是 unAccessible 字段，而 access 对外的字段为 unaccessible 。导致无法正常的抛出403。

**期望**: 配置access后，没有权限的页面，抛出403

**实际**: 配置access后，没有权限的页面，在左侧菜单被隐藏。而手动输入路径后，可以进入该页面。

![image](https://user-images.githubusercontent.com/10667077/87305097-80f3cd00-c548-11ea-857e-1e5fd34f6bfb.png)

**解决方案**: 修正 plugin-access 的字段命名，使 plugin-layout 等正确执行抛错逻辑

![image](https://user-images.githubusercontent.com/10667077/87305277-c9ab8600-c548-11ea-8744-7595febf8602.png)
