### PR TITLE
fix(layout): 修复 layout 的鉴权的逻辑问题

### DIFF
--- a/packages/plugin-layout/src/layout/index.tsx
+++ b/packages/plugin-layout/src/layout/index.tsx
@@ -7,6 +7,7 @@ import ErrorBoundary from '../component/ErrorBoundary';
 import renderRightContent from './renderRightContent';
 import { WithExceptionOpChildren } from '../component/Exception';
 import { getMatchMenu, MenuDataItem, transformRoute } from '@umijs/route-utils';
+import breadthMatchRoute from '../utils/breadthMatchRoute';
 // @ts-ignore
 import logo from '../assets/logo.svg';
 
@@ -24,23 +25,6 @@ const BasicLayout = (props: any) => {
 
   const [currentPathConfig, setCurrentPathConfig] = useState<MenuDataItem>({});
 
-  // 广度优先匹配路由
-  const breadthMatchMenu = (tree: MenuDataItem[], path: string) => {
-    let stark: MenuDataItem[] = [];
-
-    stark = stark.concat(tree);
-
-    while (stark.length) {
-      const temp = stark.shift();
-      if (temp.children) {
-        stark = stark.concat(temp.children);
-      }
-      if (temp.path === path) {
-        return temp;
-      }
-    }
-  };
-
   useEffect(() => {
     const { menuData } = transformRoute(
       props?.route?.routes || [],
@@ -49,7 +33,7 @@ const BasicLayout = (props: any) => {
       true,
     );
     // 判断是否存在该路由地址
-    const matchedMenu = breadthMatchMenu(
+    const matchedMenu = breadthMatchRoute(
       props?.route?.routes || [],
       location.pathname,
     );

--- a/packages/plugin-layout/src/layout/index.tsx
+++ b/packages/plugin-layout/src/layout/index.tsx
@@ -24,6 +24,23 @@ const BasicLayout = (props: any) => {
 
   const [currentPathConfig, setCurrentPathConfig] = useState<MenuDataItem>({});
 
+  // 广度优先匹配路由
+  const breadthMatchMenu = (tree: MenuDataItem[], path: string) => {
+    let stark: MenuDataItem[] = [];
+
+    stark = stark.concat(tree);
+
+    while (stark.length) {
+      const temp = stark.shift();
+      if (temp.children) {
+        stark = stark.concat(temp.children);
+      }
+      if (temp.path === path) {
+        return temp;
+      }
+    }
+  };
+
   useEffect(() => {
     const { menuData } = transformRoute(
       props?.route?.routes || [],
@@ -31,9 +48,21 @@ const BasicLayout = (props: any) => {
       undefined,
       true,
     );
+    // 判断是否存在该路由地址
+    const matchedMenu = breadthMatchMenu(
+      props?.route?.routes || [],
+      location.pathname,
+    );
     // 动态路由匹配
-    const currentPathConfig = getMatchMenu(location.pathname, menuData).pop();
-    setCurrentPathConfig(currentPathConfig || {});
+    let currentPathConfig = getMatchMenu(location.pathname, menuData).pop();
+
+    if (matchedMenu) {
+      currentPathConfig = {
+        ...currentPathConfig,
+        unaccessible: matchedMenu.unaccessible,
+      };
+    }
+    setCurrentPathConfig(currentPathConfig);
   }, [location.pathname]);
   // layout 是否渲染相关
   const layoutRender: any = {};

--- a/packages/plugin-layout/src/utils/breadthMatchRoute.ts
+++ b/packages/plugin-layout/src/utils/breadthMatchRoute.ts
@@ -1,0 +1,23 @@
+import { MenuDataItem } from '@umijs/route-utils';
+
+/**
+ * 广度优先匹配路由
+ * @param tree 路由树
+ * @param path 访问路径
+ */
+function breadthMatchRoute(tree: MenuDataItem[], path: string) {
+  let stark: MenuDataItem[] = [];
+
+  stark = stark.concat(tree);
+
+  while (stark.length) {
+    const temp = stark.shift();
+    if (temp.children) {
+      stark = stark.concat(temp.children);
+    }
+    if (temp.path === path) {
+      return temp;
+    }
+  }
+}
+export default breadthMatchRoute;

--- a/packages/plugin-layout/test/breadthMatchRoute.test.js
+++ b/packages/plugin-layout/test/breadthMatchRoute.test.js
@@ -1,0 +1,22 @@
+import breadthMatchRoute from '../src/utils/breadthMatchRoute';
+import { normalMenu } from './routes/normal';
+
+describe('breadthMatchRoute', () => {
+  /**
+   * 测试了以下场景：
+   *  1. 匹配到路由
+   */
+  test('existence', () => {
+    const matchedMenu = breadthMatchRoute(normalMenu, '/test233');
+    expect(matchedMenu.path).toEqual('/test233');
+  });
+
+  /**
+   * 测试了以下场景:
+   *  1. 匹配不到路由
+   */
+  test('non-existence', () => {
+    const matchedMenu = breadthMatchRoute(normalMenu, '/non-existence');
+    expect(matchedMenu).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
**问题内容**: 修复 layout 的鉴权逻辑问题

**期望**: 配置 access 后，没有权限的页面，抛出403

**实际**: 配置 access 后，没有权限的页面，在左侧菜单被隐藏。而手动输入路径后，可以进入该页面。

![image](https://user-images.githubusercontent.com/10667077/87305097-80f3cd00-c548-11ea-857e-1e5fd34f6bfb.png)

**过程**: 

- 调试 **plugin-layout/src/layout/index.tsc** 文件
 发现 **props.route.routes** 在经过 **transformRoute** 函数转换后
 **unaccessible**  为 **true** 的路由都会被过滤掉
![image](https://user-images.githubusercontent.com/10667077/87412274-6cbcd800-c5fb-11ea-8470-e185d6f933be.png)

- 当 **getMatchMenu** 函数在匹配时，无法找到对应的 **location.pathname** 为 **undefined**

![image](https://user-images.githubusercontent.com/10667077/87412661-dd63f480-c5fb-11ea-95db-013318976c67.png)

- 紧接着在 **setCurrentPathConfig** 时候，设置了一个默认值 **{}**
![image](https://user-images.githubusercontent.com/10667077/87412833-14d2a100-c5fc-11ea-875f-185a363003ef.png)

- 最后, 当 **currentPathConfig** 传递到 **plugin-layout/src/component/Excetion/index.tsc** 时，不会进入任何抛错逻辑
![image](https://user-images.githubusercontent.com/10667077/87413093-7135c080-c5fc-11ea-9f08-1ca8b40b99bc.png)

**解决方案**:
- 增加路由是否存在匹配，匹配不到则会进入 404逻辑判断
- 如果匹配到对应路由，则传递 **unaccessible** 字段。
- 移除 **setCurrentPathConfig** 默认值
![image](https://user-images.githubusercontent.com/10667077/87413251-a6daa980-c5fc-11ea-8c4d-ceb24e89eece.png)

