### PR TITLE
feat(qiankun): support to pass container for different sub apps

### DIFF
--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -143,7 +143,7 @@ export default function(api: IApi) {
     () =>
       `
     export const bootstrap = qiankun_genBootstrap(clientRender);
-    export const mount = qiankun_genMount();
+    export const mount = qiankun_genMount('${api.config.mountElementId}');
     export const unmount = qiankun_genUnmount('${api.config.mountElementId}');
     export const update = qiankun_genUpdate();
 

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts
@@ -58,7 +58,7 @@ export function genBootstrap(oldRender: typeof noop) {
   };
 }
 
-export function genMount() {
+export function genMount(mountElementId: string) {
   return async (props?: any) => {
     setModelState(props);
 
@@ -84,6 +84,9 @@ export function genMount() {
     };
     defer.resolve({
       callback,
+      // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围
+      // 避免多个子应用出现在同一主应用时出现 mount 冲突
+      container: props.container?.querySelector(mountElementId) || mountElementId,
     });
     // 第一次 mount umi 会自动触发 render，非第一次 mount 则需手动触发
     if (hasMountedAtLeastOnce) {

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts
@@ -82,12 +82,15 @@ export function genMount(mountElementId: string) {
         props.setLoading(false);
       }
     };
+    // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围
+    // 避免多个子应用出现在同一主应用时出现 mount 冲突
+    const rootElement = props.container?.querySelector(mountElementId);
+
     defer.resolve({
       callback,
-      // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围
-      // 避免多个子应用出现在同一主应用时出现 mount 冲突
-      container: props.container?.querySelector(mountElementId) || mountElementId,
+      ...(rootElement ? { rootElement } : {}),
     });
+
     // 第一次 mount umi 会自动触发 render，非第一次 mount 则需手动触发
     if (hasMountedAtLeastOnce) {
       render();

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts
@@ -84,7 +84,7 @@ export function genMount(mountElementId: string) {
     };
     // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围
     // 避免多个子应用出现在同一主应用时出现 mount 冲突
-    const rootElement = props.container?.querySelector(mountElementId);
+    const rootElement = props?.container?.querySelector(mountElementId);
 
     defer.resolve({
       callback,


### PR DESCRIPTION
## 修改内容
- 支持基于 `props.container` 查找 `mountElementId` 并传入 umi 的 render，用于限定子应用 mount 节点的查找范围

## 相关 PR
- umijs/umi#5067