### PR TITLE
feat(layout): transform icons for convention routing

### DIFF
--- a/packages/plugin-layout/src/index.ts
+++ b/packages/plugin-layout/src/index.ts
@@ -126,20 +126,29 @@ export default (api: IApi) => {
     });
 
     // 生效临时的 icon 文件
-    const { userConfig } = api;
-    const icons = formatter(userConfig.routes);
-    let iconsString = icons.map(
-      iconName => `import ${iconName} from '@ant-design/icons/${iconName}'`,
-    );
-    api.writeTmpFile({
-      path: join(DIR_NAME, 'icons.ts'),
-      content: `
+    function generateIcons(routes) {
+      const icons = formatter(routes);
+      let iconsString = icons.map(
+        iconName => `import ${iconName} from '@ant-design/icons/${iconName}'`,
+      );
+      api.writeTmpFile({
+        path: join(DIR_NAME, 'icons.ts'),
+        content: `
   ${iconsString.join(';\n')}
   export default {
     ${icons.join(',\n')}
   }
       `,
-    });
+      });
+    }
+    const {
+      userConfig: { routes },
+    } = api;
+    if (routes) {
+      generateIcons(routes);
+    } else {
+      api.getRoutes().then(generateIcons);
+    }
 
     api.writeTmpFile({
       path: join(DIR_NAME, 'runtime.tsx'),


### PR DESCRIPTION
When using convention routing, the `menu.icon` string would not be transformed to `Icon` component. Fix that 

closes umijs/umi#4095