### PR TITLE
fix(dva): upperCamelCase model's default specifier

### DIFF
--- a/packages/plugin-dva/src/index.ts
+++ b/packages/plugin-dva/src/index.ts
@@ -106,9 +106,8 @@ export default (api: IApi) => {
             .join('\n'),
           RegisterModelImports: models
             .map((path, index) => {
-              return `import Model${basename(
-                path,
-                extname(path),
+              return `import Model${lodash.upperFirst(
+                lodash.camelCase(basename(path, extname(path))),
               )}${index} from '${path}';`;
             })
             .join('\r\n'),
@@ -116,7 +115,7 @@ export default (api: IApi) => {
             .map((path, index) => {
               // prettier-ignore
               return `
-app.model({ namespace: '${basename(path, extname(path))}', ...Model${basename(path, extname(path))}${index} });
+app.model({ namespace: '${lodash.upperFirst(lodash.camelCase(basename(path, extname(path))))}', ...Model${basename(path, extname(path))}${index} });
           `.trim();
             })
             .join('\r\n'),

--- a/packages/plugin-dva/src/index.ts
+++ b/packages/plugin-dva/src/index.ts
@@ -115,7 +115,7 @@ export default (api: IApi) => {
             .map((path, index) => {
               // prettier-ignore
               return `
-app.model({ namespace: '${lodash.upperFirst(lodash.camelCase(basename(path, extname(path))))}', ...Model${basename(path, extname(path))}${index} });
+app.model({ namespace: '${basename(path, extname(path))}', ...Model${lodash.upperFirst(lodash.camelCase(basename(path, extname(path))))}${index} });
           `.trim();
             })
             .join('\r\n'),


### PR DESCRIPTION
Close #339

eg.

```
import ModelFooBar0 from '/private/tmp/sorrycc-Jd7VZW/models/foo-bar.ts';
import ModelFoo1 from '/private/tmp/sorrycc-Jd7VZW/models/foo.ts';
import ModelModel2 from '/private/tmp/sorrycc-Jd7VZW/pages/bar/model.ts';
import ModelModel3 from '/private/tmp/sorrycc-Jd7VZW/pages/foo/model.ts';
```
