### PR TITLE
fix(qiankun): no apps default value causes runtime error

### DIFF
--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -34,6 +34,7 @@ export default function(api: IApi) {
     qiankun: {
       ...config.qiankun,
       master: {
+        apps: [],
         ...JSON.parse(process.env.INITIAL_QIANKUN_MASTER_OPTIONS || '{}'),
         ...(config.qiankun || {}).master,
       },


### PR DESCRIPTION
主、微应用都是使用 `umi` 开发，主应用通过 `loadMicroApp` 手动加载微应用，使用该插件仅作为注册入口。`.umirc.ts` 中的插件配置若没有传 `apps` 字段，会导致主应用运行报错。