### PR TITLE
fix: fix a warning when build plugin qiankun

### DIFF
--- a/packages/plugin-qiankun/src/common.ts
+++ b/packages/plugin-qiankun/src/common.ts
@@ -26,7 +26,7 @@ function testPathWithStaticPrefix(pathPrefix: string, realPath: string) {
 }
 
 function testPathWithDynamicRoute(dynamicRoute: string, realPath: string) {
-  return pathToRegexp.default(dynamicRoute, {
+  return pathToRegexp(dynamicRoute, {
     strict: true,
     end: false,
   }).test(realPath);

--- a/packages/plugin-qiankun/src/common.ts
+++ b/packages/plugin-qiankun/src/common.ts
@@ -26,7 +26,7 @@ function testPathWithStaticPrefix(pathPrefix: string, realPath: string) {
 }
 
 function testPathWithDynamicRoute(dynamicRoute: string, realPath: string) {
-  return pathToRegexp.default(dynamicRoute, [], {
+  return pathToRegexp.default(dynamicRoute, {
     strict: true,
     end: false,
   }).test(realPath);

--- a/packages/plugin-qiankun/src/common.ts
+++ b/packages/plugin-qiankun/src/common.ts
@@ -26,9 +26,10 @@ function testPathWithStaticPrefix(pathPrefix: string, realPath: string) {
 }
 
 function testPathWithDynamicRoute(dynamicRoute: string, realPath: string) {
-  return !!pathToRegexp(dynamicRoute, { strict: true, end: false }).exec(
-    realPath,
-  );
+  return pathToRegexp.default(dynamicRoute, [], {
+    strict: true,
+    end: false,
+  }).test(realPath);
 }
 
 export function testPathWithPrefix(pathPrefix: string, realPath: string) {

--- a/packages/plugin-qiankun/src/common.ts
+++ b/packages/plugin-qiankun/src/common.ts
@@ -3,7 +3,7 @@
  * @since 2019-06-20
  */
 
-import pathToRegexp from 'path-to-regexp';
+import * as pathToRegexp from 'path-to-regexp';
 
 export const defaultMountContainerId = 'root-subapp';
 


### PR DESCRIPTION
✔ Webpack
  Compiled successfully in 43.77s

 WARNING  Compiled with 1 warnings                                                                                    2:38:48 ├F10: PM┤

 warning  in ./src/.umi/plugin-qiankun/common.ts

"export 'default' (imported as 'pathToRegexp') was not found in 'path-to-regexp'