### PR TITLE
fix: add anticon className to layout right content for support pro-layout mix mode

### DIFF
--- a/packages/plugin-layout/src/layout/renderRightContent.tsx
+++ b/packages/plugin-layout/src/layout/renderRightContent.tsx
@@ -60,7 +60,7 @@ export default function renderRightContent(
 
   return (
     initialState && (
-      <div className="umi-plugin-layout-right">
+      <div className="umi-plugin-layout-right anticon">
         {runtimeLayout.logout ? (
           <Dropdown
             overlay={menu}
@@ -69,8 +69,8 @@ export default function renderRightContent(
             {avatar}
           </Dropdown>
         ) : (
-          avatar
-        )}
+            avatar
+          )}
         {SelectLang && <SelectLang />}
       </div>
     )

--- a/packages/plugin-layout/src/layout/style.less
+++ b/packages/plugin-layout/src/layout/style.less
@@ -52,3 +52,7 @@
     }
   }
 }
+
+.umi-plugin-layout-name {
+  margin-left: 8px;
+}


### PR DESCRIPTION
pro-layout 6.x 版本的 mix 模式头部默认是黑底，添加 `anticon` className 是的头部文字可以自适应为白色。

另外修复了 name 左边缺少 margin 的问题。