### PR TITLE
fix(qiankun): type missing in MicroAppWithMemoHistory

### DIFF
--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -25,7 +25,7 @@ type MemoryHistory = {
   type?: 'memory',
 } & MemoryHistoryBuildOptions;
 
-type Props = {
+export type Props = {
   name: string;
   settings?: FrameworkConfiguration;
   base?: string;


### PR DESCRIPTION
## Description

Add props export for `MicroApp` component, to fix `MicroAppProps` missing bug in `MicroAppWithMemoHistory` component: https://github.com/umijs/plugins/blob/747e0e7b5a4e7b99c253457c2c852c73b1ec7021/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl#L2