### PR TITLE
feat(qiankun): support to access history ref for slave

### DIFF
--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -7,7 +7,7 @@ import {
 } from 'qiankun';
 import React, { useEffect, useRef, useState } from 'react';
 // @ts-ignore
-import { useModel } from 'umi';
+import { useModel, History } from 'umi';
 import { concat, mergeWith, noop } from 'lodash';
 import { BrowserHistoryBuildOptions, HashHistoryBuildOptions, MemoryHistoryBuildOptions, } from 'history-with-query';
 
@@ -32,6 +32,7 @@ export type Props = {
   history?: 'hash' | 'browser' | 'memory' | HashHistory | BrowserHistory | MemoryHistory;
   getMatchedBase?: () => string;
   loader?: (loading: boolean) => React.ReactNode;
+  onHistoryInit?: History => void;
 } & Record<string, any>;
 
 function unmountMicroApp(microApp?: MicroAppType) {

--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -32,7 +32,7 @@ export type Props = {
   history?: 'hash' | 'browser' | 'memory' | HashHistory | BrowserHistory | MemoryHistory;
   getMatchedBase?: () => string;
   loader?: (loading: boolean) => React.ReactNode;
-  onHistoryInit?: History => void;
+  onHistoryInit?: (history: History) => void;
 } & Record<string, any>;
 
 function unmountMicroApp(microApp?: MicroAppType) {

--- a/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
@@ -8,6 +8,7 @@ export interface Props extends MicroAppProps {
 export function MicroAppWithMemoHistory(componentProps: Props) {
   const { url, ...rest } = componentProps;
   const history = useRef();
+  // url 的变更不会透传给下游，组件内自己会处理掉，所以这里直接用 ref 来存
   const historyOpts = useRef({
     type: 'memory',
     initialEntries: [url],

--- a/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { MicroApp, Props as MicroAppProps } from './MicroApp';
 
 export interface Props extends MicroAppProps {
@@ -6,7 +6,16 @@ export interface Props extends MicroAppProps {
 }
 
 export function MicroAppWithMemoHistory(componentProps: Props) {
+  const history = useRef();
   const { url, ...rest } = componentProps;
+
+  useEffect(() => {
+    // push history for slave app when url property changed
+    // the initial url will be ignored because the history ref has not been initialized
+    if (history.current && url) {
+      history.current.push(url);
+    }
+  }, [url]);
 
   return (
     <MicroApp
@@ -16,6 +25,7 @@ export function MicroAppWithMemoHistory(componentProps: Props) {
         initialEntries: [url],
         initialIndex: 1,
       }}
+      historyRef={history}
     />
   )
 }

--- a/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { MicroApp, Props as MicroAppProps } from './MicroApp';
 
 export interface Props extends MicroAppProps {
@@ -6,14 +6,14 @@ export interface Props extends MicroAppProps {
 }
 
 export function MicroAppWithMemoHistory(componentProps: Props) {
-  const history = useRef();
+  const [history, setHistory] = useState(null);
   const { url, ...rest } = componentProps;
 
   useEffect(() => {
     // push history for slave app when url property changed
-    // the initial url will be ignored because the history ref has not been initialized
-    if (history.current && url) {
-      history.current.push(url);
+    // the initial url will be ignored because the history has not been initialized
+    if (history && url) {
+      history.push(url);
     }
   }, [url]);
 
@@ -25,7 +25,7 @@ export function MicroAppWithMemoHistory(componentProps: Props) {
         initialEntries: [url],
         initialIndex: 1,
       }}
-      historyRef={history}
+      onHistoryInit={h => setHistory(h)}
     />
   )
 }

--- a/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroAppWithMemoHistory.tsx.tpl
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import { MicroApp, Props as MicroAppProps } from './MicroApp';
 
 export interface Props extends MicroAppProps {
@@ -6,26 +6,28 @@ export interface Props extends MicroAppProps {
 }
 
 export function MicroAppWithMemoHistory(componentProps: Props) {
-  const [history, setHistory] = useState(null);
   const { url, ...rest } = componentProps;
+  const history = useRef();
+  const historyOpts = useRef({
+    type: 'memory',
+    initialEntries: [url],
+    initialIndex: 1,
+  });
+  const historyInitHandler = useCallback(h => history.current = h, []);
 
   useEffect(() => {
     // push history for slave app when url property changed
     // the initial url will be ignored because the history has not been initialized
-    if (history && url) {
-      history.push(url);
+    if (history.current && url) {
+      history.current.push(url);
     }
   }, [url]);
 
   return (
     <MicroApp
       {...rest}
-      history={{
-        type: 'memory',
-        initialEntries: [url],
-        initialIndex: 1,
-      }}
-      onHistoryInit={h => setHistory(h)}
+      history={historyOpts.current}
+      onHistoryInit={historyInitHandler}
     />
   )
 }

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
@@ -91,9 +91,9 @@ export function genMount(mountElementId: string) {
           props.setLoading(false);
         }
 
-        // 支持将子应用的 history 通过 ref 回传给父应用
-        if (props?.historyRef?.current !== undefined) {
-          props.historyRef.current = history;
+        // 支持将子应用的 history 回传给父应用
+        if (typeof props?.onHistoryInit === 'function') {
+          onHistoryInit(history);
         }
       },
       // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom';
 // @ts-ignore
-import { plugin, ApplyPluginsType, setCreateHistoryOptions } from 'umi';
+import { plugin, ApplyPluginsType, setCreateHistoryOptions, history } from 'umi';
 import { setModelState } from './qiankunModel';
 // @ts-ignore
 import { getSlaveOptions } from './slaveOptions';
@@ -89,6 +89,11 @@ export function genMount(mountElementId: string) {
           typeof props?.setLoading === 'function'
         ) {
           props.setLoading(false);
+        }
+
+        // 支持将子应用的 history 通过 ref 回传给父应用
+        if (props?.historyRef?.current !== undefined) {
+          props.historyRef.current = history;
         }
       },
       // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
@@ -93,7 +93,7 @@ export function genMount(mountElementId: string) {
 
         // 支持将子应用的 history 回传给父应用
         if (typeof props?.onHistoryInit === 'function') {
-          onHistoryInit(history);
+          props.onHistoryInit(history);
         }
       },
       // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围


### PR DESCRIPTION
## 修改内容

1. 支持通过 `historyRef` 来获取子应用的 history 实例，进而在外层控制子应用路由切换
2. `MicroAppWithMemoHistory` 内置组件支持响应 `url` 参数的变化去修改 子应用的 history