### PR TITLE
fix(layout): 404 page is not automatically redirected

### DIFF
--- a/packages/plugin-layout/src/layout/index.tsx
+++ b/packages/plugin-layout/src/layout/index.tsx
@@ -57,7 +57,9 @@ const BasicLayout = (props: any) => {
 
   // plugin-initial-state 未开启
   const { initialState, loading, setInitialState } = initialInfo;
-  const [currentPathConfig, setCurrentPathConfig] = useState<MenuDataItem>({});
+  const [currentPathConfig, setCurrentPathConfig] = useState<
+    MenuDataItem | undefined
+  >();
 
   useEffect(() => {
     const { menuData } = transformRoute(
@@ -68,7 +70,7 @@ const BasicLayout = (props: any) => {
     );
     // 动态路由匹配
     const currentPathConfig = getMatchMenu(location.pathname, menuData).pop();
-    setCurrentPathConfig(currentPathConfig || {});
+    setCurrentPathConfig(currentPathConfig);
   }, [location.pathname]);
 
   // layout 是否渲染相关


### PR DESCRIPTION
`currentPathConfig`的默认值为`undefined`，否则`Exception404`组件显示不出来。

https://github.com/umijs/plugins/blob/e652620eee253e1b2aa10be9c7fb98be87d96f81/packages/plugin-layout/src/component/Exception/index.tsx#L61-L63