### PR TITLE
fix(layout): menu.name is not localized as menu name

### DIFF
--- a/packages/plugin-layout/src/runtime.tsx.tpl
+++ b/packages/plugin-layout/src/runtime.tsx.tpl
@@ -25,6 +25,10 @@ function formatter(data: MenuDataItem[]): MenuDataItem[] {
     return data;
   }
   (data || []).forEach((item = { path: '/' }) => {
+    // Copy item.name from item.menu.name
+    if (!item.name && item.menu?.name) {
+      item.name = item.menu.name;
+    }
     // 兼容旧的写法 menu:{icon:""}
     const icon = item.icon ? item.icon : item.menu ? item.menu.icon : '';
     if (icon && typeof icon === "string") {


### PR DESCRIPTION
Copy `routeItem.menu.name` to `routeItem.name`, otherwise the menu name is not localized while `userConfig.layout.locale` was set to `true`.
当`userConfig.layout.locale`设置为`true`时，菜单名称没有被本地化，需要把`routeItem.menu.name` 拷贝到 `routeItem.name`上