### PR TITLE
feat: add useCustomLayout api

### DIFF
--- a/packages/plugin-layout/src/index.ts
+++ b/packages/plugin-layout/src/index.ts
@@ -187,17 +187,29 @@ export default (api: IApi) => {
       content: readFileSync(join(__dirname, 'runtime.tsx.tpl'), 'utf-8'),
     });
   });
-  api.modifyRoutes(routes => {
-    return [
-      {
-        path: '/',
-        component: utils.winPath(
-          join(api.paths.absTmpPath || '', DIR_NAME, 'Layout.tsx'),
-        ),
-        routes,
-      },
-    ];
-  });
+
+  if (!api.userConfig?.layout?.useCustomLayout) {
+    api.modifyRoutes(routes => {
+      return [
+        {
+          path: '/',
+          component: utils.winPath(
+            join(api.paths.absTmpPath || '', DIR_NAME, 'Layout.tsx'),
+          ),
+          routes,
+        },
+      ];
+    });
+  }
+
+  api.addUmiExports(() => [
+    {
+      specifiers: [{ local: 'default', exported: 'PluginLayout' }],
+      source: utils.winPath(
+        join(api.paths.absTmpPath || '', DIR_NAME, 'Layout.tsx'),
+      ),
+    },
+  ]);
 
   api.addRuntimePlugin(() => ['@@/plugin-layout/runtime.tsx']);
 };


### PR DESCRIPTION
支持配置 useCustomLayout ，不自动引入 PluginLayout ，用于一些需要复杂设计 Layout 的场景，比如现在的尝试的 keep-alive 和多 tabs 方案，都要以这个为基础，也能解下面这个[问题](https://github.com/ant-design/ant-design-pro/issues/6605#issuecomment-722092469)。
![image](https://user-images.githubusercontent.com/11746742/98226654-47c8e800-1f91-11eb-94bc-af3e554dd7e6.png)

用 ant-design-pro 为例，如下修改，与现在的效果一致。

https://github.com/ant-design/ant-design-pro/blob/476bfbfe8415fab918f9c66fc0c43368e1443a97/config/config.ts#L15-L19

```ts
 layout: {
    name: 'Ant Design Pro',
    locale: true,
    useCustomLayout: true, // 新增这行
    ...defaultSettings,
  },
```

新建 `src/layouts/index.tsx`

```tsx
import React from 'react';
import { PluginLayout } from 'umi';

const Layout: React.FC = ({ children,...other }) => <PluginLayout {...other}>{children}</PluginLayout>;

export default Layout;
```
[路由配置](https://github.com/ant-design/ant-design-pro/blob/476bfbfe8415fab918f9c66fc0c43368e1443a97/config/routes.ts#L1)再加一层

```ts
export default [
  {
    path: '/',
    component: '../layouts',
    routes: [
      {
        path: '/user',
        layout: false,
        routes: [
          {
            name: 'login',
            path: '/user/login',
            component: './user/login',
          },
        ],
      },
      {
        path: '/welcome',
        name: 'welcome',
        icon: 'smile',
        component: './Welcome',
      },
      ...
    ]
  }];

```

