### PR TITLE
fix #426 useModel 父子应用通信无法在切换应用时保持最新的全局数据

### DIFF
--- a/packages/plugin-qiankun/src/slave/qiankunModel.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/qiankunModel.ts.tpl
@@ -7,7 +7,7 @@ let setModelState = (val: any) => {
 
 export default () => {
   const [state, setState] = useState(initState);
-  setModelState = (val) => {
+  setModelState = (val: any) => {
     initState = val;
     setState(val);
   };

--- a/packages/plugin-qiankun/src/slave/qiankunModel.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/qiankunModel.ts.tpl
@@ -7,7 +7,10 @@ let setModelState = (val: any) => {
 
 export default () => {
   const [state, setState] = useState(initState);
-  setModelState = setState;
+  setModelState = (val) => {
+    initState = val;
+    setState(val);
+  };
 
   return state;
 };


### PR DESCRIPTION
#426 这里每次重新挂载子应用时都会从 initState 初始化，然而这个 initState 只在首次挂载才会被赋值，在之后切换过来时则直接作为 useState 的初始值

close #426