### PR TITLE
fix: remove broken webpack alias in plugin-preact

### DIFF
--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-preact#readme",
   "dependencies": {
-    "preact": "^10.3.4"
+    "preact": "^10.5.7"
   },
   "peerDependencies": {
     "umi": "3.x"

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -9,10 +9,6 @@ export default (api: IApi) => {
       .set('preact', require.resolve('preact'))
       .set('react', dirname(require.resolve('preact/compat/package.json')))
       .set('react-dom', dirname(require.resolve('preact/compat/package.json')))
-      .set(
-        'create-react-class',
-        require.resolve('preact-compat/lib/create-react-class'),
-      );
     return memo;
   });
 


### PR DESCRIPTION
在最新的 `umi@^3.2.28` 中使用 `plugin-preact` 启动会报如下错误：

```shell
$ umi dev
Cannot find module 'preact-compat/lib/create-react-class'
Require stack:
- /Users/username/projectname/node_modules/@umijs/plugin-preact/lib/index.js
# ....
```

因为 `preact@10` 以后 core 包中已经包含 compat 了，所以不存在 preact-compat 这个包，猜测可能是遗留的代码
移除对应的 alias 后，项目可以正常启动并打包

另： 将 preact 升级到了最新的版本

