### PR TITLE
feat: using esbuild-loader

### DIFF
--- a/packages/plugin-esbuild/package.json
+++ b/packages/plugin-esbuild/package.json
@@ -28,6 +28,6 @@
     "access": "public"
   },
   "dependencies": {
-    "esbuild-webpack-plugin": "^1.0.0-beta.3"
+    "esbuild-loader": "~2.6.3"
   }
 }

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -1,4 +1,5 @@
 import { IApi, BundlerConfigType } from 'umi';
+import { ESBuildPlugin, ESBuildMinifyPlugin } from 'esbuild-loader';
 
 export default (api: IApi) => {
   api.describe({
@@ -15,16 +16,20 @@ export default (api: IApi) => {
     if (memo.optimization) {
       const optsMap = {
         [BundlerConfigType.csr]: {
-          target: 'chrome49',
+          target: 'es2015',
+          minify: true,
         },
         [BundlerConfigType.ssr]: {
           target: 'node10',
+          minify: true,
         },
       };
       const opts = optsMap[type] || optsMap[BundlerConfigType.csr];
-      memo.optimization.minimizer = [
-        new (require('esbuild-webpack-plugin').default)(opts),
-      ];
+      memo.optimization.minimize = true;
+      memo.optimization.minimizer = [new ESBuildMinifyPlugin(opts)];
+    }
+    if (memo.plugins) {
+      memo.plugins.push(new ESBuildPlugin());
     }
     return memo;
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8973,17 +8973,20 @@ es6-weak-map@^2.0.2:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
-esbuild-webpack-plugin@^1.0.0-beta.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/esbuild-webpack-plugin/-/esbuild-webpack-plugin-1.0.5.tgz#68a6a377a84c991da1a0fc302830f514c9d47472"
-  integrity sha512-X/ektio8dxHD/bYk1BhT7XZw7U1ZJDu8VRjhc81W12Mizw0Fti+Wp4W4u1e9PiMdeDz/SXAO3U0A37wV7XT0wA==
+esbuild-loader@~2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/esbuild-loader/-/esbuild-loader-2.6.3.tgz#8a885cca4235c8fe58e5ef3d1427633bb4566f32"
+  integrity sha512-zUzxOJGfgoEKEXuBCtyothM5XulbQBvHlt0yLWBWWXe7QKJ9T8O8itsqTR4nHgUN0yCRgm3+uliNZssiXPM9/g==
   dependencies:
-    esbuild "^0.6.8"
+    esbuild "^0.8.17"
+    loader-utils "^2.0.0"
+    type-fest "^0.20.2"
+    webpack-sources "^2.2.0"
 
-esbuild@^0.6.8:
-  version "0.6.27"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.6.27.tgz#e8f4d6b3bb3b4156a5e5679b5b582561b075828d"
-  integrity sha512-oonxxg/ExZt9tYMPnEUDYAN7YefEPsC21pXez5rwKcCPAF6gzMuxLvAdbU4dCT8Tp0I2avODz61vrGyu5wR/uA==
+esbuild@^0.8.17:
+  version "0.8.23"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.23.tgz#8c4ccd3abb5f7b4ae9f31c571971517be4ae60d2"
+  integrity sha512-LkgCmotGnhVgRGxjDkTBBYrnJ5stcxK+40cEJGtXUS16hcAWy90cn1qjxKCogzLPJ75gW/L6ejly7VKrMstVGQ==
 
 escalade@^3.0.2:
   version "3.0.2"
@@ -19536,6 +19539,11 @@ type-fest@^0.13.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
   integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
@@ -20349,6 +20357,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@4.44.1:
   version "4.44.1"


### PR DESCRIPTION
换成 [esbuild-loader](https://github.com/privatenumber/esbuild-loader)，主要 [esbuild-webpack-plugin](https://github.com/sorrycc/esbuild-webpack-plugin) 有下面几点：
1、两个 esbuild 实例不会退出（Client build + Server build 的时候）
2、esbuild 未更新到最新版本