### PR TITLE
Polish added to the list of language config map

### DIFF
--- a/packages/plugin-locale/src/templates/SelectLang.tpl
+++ b/packages/plugin-locale/src/templates/SelectLang.tpl
@@ -279,6 +279,12 @@ const defaultLangUConfigMap = {
     icon: '🇳🇱',
     title: 'Taal'
   },
+  'pl-PL': {
+    lang: 'pl-PL',
+    label: 'Polski',
+    icon: '🇵🇱',
+    title: 'Język'
+  },
   'pt-BR': {
     lang: 'pt-BR',
     label: 'Português',


### PR DESCRIPTION
Polish language was missing in the config map, rendering was innacurate.