### PR TITLE
在model.js的Subscription中使用query，会报错'query' does not exist on type 'Location<unknown>'

### DIFF
--- a/packages/plugin-dva/src/connect.tpl
+++ b/packages/plugin-dva/src/connect.tpl
@@ -1,9 +1,9 @@
 import { IRoute } from '@umijs/core';
 import { AnyAction } from 'redux';
 import React from 'react';
-import { EffectsCommandMap, SubscriptionAPI } from 'dva';
+import { EffectsCommandMap } from 'dva';
 import { match } from 'react-router-dom';
-import { Location, LocationState, History } from 'history';
+import { Location, LocationState, History } from 'history-with-query';
 
 {{{ dvaHeadExport }}}
 
@@ -36,6 +36,11 @@ export type Dispatch = <P = any, C = (payload: P) => void>(action: {
   callback?: C;
   [key: string]: any;
 }) => any;
+
+export interface SubscriptionAPI {
+  history: History,
+  dispatch: Dispatch,
+}
 
 export type Subscription = (api: SubscriptionAPI, done: Function) => void | Function;
 


### PR DESCRIPTION
在umi中，`packages/types/index.d.ts`使用了带query的history，`import { History, Location } from 'history-with-query';`，而在dva中导入的还是不带history的，尝试加上