### PR TITLE
Revert "feat(qiankun): 移除主应用对 mountElementId 的变更 (#515)"

### DIFF
--- a/packages/plugin-qiankun/src/common.ts
+++ b/packages/plugin-qiankun/src/common.ts
@@ -6,6 +6,8 @@
 import * as pathToRegexp from 'path-to-regexp';
 import { ReactComponentElement } from 'react';
 
+export const defaultMountContainerId = 'root-subapp';
+
 // @formatter:off
 export const noop = () => {};
 // @formatter:on

--- a/packages/plugin-qiankun/src/constants.ts
+++ b/packages/plugin-qiankun/src/constants.ts
@@ -1,3 +1,4 @@
+export const defaultMasterRootId = 'root-master';
 export const defaultHistoryType = 'browser';
 export const qiankunStateForSlaveModelNamespace = '@@qiankunStateForSlave';
 export const qiankunStateFromMasterModelNamespace = '@@qiankunStateFromMaster';

--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -7,6 +7,7 @@ import modifyRoutes from './modifyRoutes';
 import { hasExportWithName } from './utils';
 import {
   defaultHistoryType,
+  defaultMasterRootId,
   qiankunStateForSlaveModelNamespace,
 } from '../constants';
 
@@ -28,6 +29,7 @@ export default function(api: IApi) {
 
   api.modifyDefaultConfig(config => ({
     ...config,
+    mountElementId: defaultMasterRootId,
     disableGlobalVariables: true,
     qiankun: {
       ...config.qiankun,

--- a/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
@@ -7,7 +7,7 @@ import { prefetchApps, registerMicroApps, start } from 'qiankun';
 // @ts-ignore
 import { ApplyPluginsType, plugin, getMicroAppRouteComponent } from 'umi';
 
-import { noop, patchMicroAppRoute, testPathWithPrefix, toArray } from './common';
+import { defaultMountContainerId, noop, patchMicroAppRoute, testPathWithPrefix, toArray } from './common';
 import { defaultHistoryType } from './constants';
 import { getMasterOptions, setMasterOptions } from './masterOptions';
 // @ts-ignore
@@ -141,7 +141,6 @@ async function useLegacyRegisterMode(
     'sub apps must be config when using umi-plugin-qiankun',
   );
 
-  const defaultMountContainerId = 'root-subapp';
   registerMicroApps(
     apps.map(
       ({


### PR DESCRIPTION
This reverts commit d5e140c7

有主应用 umi3 子应用 umi2 的场景，移除了 root-master 就会导致 umi2 子应用直接渲染到主应用的根节点了..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/plugins/516)
<!-- Reviewable:end -->
