### PR TITLE
fix(qiankun): rootElement 覆盖用户设置

### DIFF
--- a/packages/plugin-qiankun/src/slave/slaveRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/slaveRuntimePlugin.ts.tpl
@@ -19,6 +19,7 @@ export function modifyClientRenderOpts(memo: any) {
   if (clientRenderOpts) {
     const history = clientRenderOpts.getHistory();
     delete clientRenderOpts.getHistory;
+    delete clientRenderOpts.rootElement;
     clientRenderOpts.history = history;
   }
 


### PR DESCRIPTION
取了clientRenderOptsStack 里的第一个，这样 rootElement 永远都是第一次设置的。用户自己 modifyClientRenderOpts 设置的会不生效 