### PR TITLE
fix(qiankun): runtime routes not loaded correctly

### DIFF
--- a/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
@@ -58,10 +58,7 @@ export function patchRoutes(opts: { routes: IRouteProps[] }) {
     const getRootRoutes = (routes: IRouteProps[]) => {
       const rootRoute = routes.find(route => route.path === '/');
       if (rootRoute) {
-        if (!rootRoute.routes) {
-          rootRoute.routes = [];
-        }
-        return rootRoute.routes;
+        return getRootRoutes(rootRoute.routes || []);
       }
 
       return routes;


### PR DESCRIPTION
### plugin-layout 和 plugin-qiankun 一起使用时，微应用配置的运行时路由没有被正确的添加到 layout 的 routes 中。


umi 自动生成的路由：
```javascript
export function getRoutes() {
  const routes = [
  {
    "path": "/",
    "component": require('yourProject/src/.umi/plugin-setting-drawer/SettingDrawer.tsx').default,
    "routes": [
      {
        "path": "/",
        "component": require('yourProject/src/.umi/plugin-layout/Layout.tsx').default,
        "routes": [
          {
            "path": "/",
            "component": require('@/layouts/index').default,
            "routes": [
              {
                "path": "/home",
                "component": require('@/pages/home').default,
                "exact": true
              }
            ]
          }
        ]
      }
    ]
  }
];
```

src/app.ts 中添加的 qiankun 配置：
```
export const qiankun = fetch('/config').then(({ apps }) => {
  return {
    apps,
    routes: [
      {
        path: '/app1',
        microApp: 'app1',
      }    
    ]
  }
});
```