### PR TITLE
fix(layout): add React.FC to fix "React declared but never read" of "tsc --noEmit"

### DIFF
--- a/packages/plugin-layout/src/component/logo.tsx
+++ b/packages/plugin-layout/src/component/logo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const LogoIcon = () => {
+const LogoIcon: React.FC = () => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
When using v5 of ant-design-pro to run "npm run tsc", the following error will appear:

import React from 'react';
       ^
'React' is declared but its value is never read.(ts6133)