### PR TITLE
Revert "fix(qiankun): runtime routes not loaded correctly (#541)"

### DIFF
--- a/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
@@ -80,7 +80,10 @@ export function patchRoutes(opts: { routes: IRouteProps[] }) {
     const getRootRoutes = (routes: IRouteProps[]) => {
       const rootRoute = routes.find(route => route.path === '/');
       if (rootRoute) {
-        return getRootRoutes(rootRoute.routes || []);
+        if (!rootRoute.routes) {
+          rootRoute.routes = [];
+        }
+        return rootRoute.routes;
       }
 
       return routes;


### PR DESCRIPTION
This reverts commit ea086eef

revert https://github.com/umijs/plugins/pull/541 ，不兼容根路由是叶子节点的场景