### PR TITLE
feat(esbuild): exposes minify pure config

### DIFF
--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -22,9 +22,10 @@ export default (api: IApi) => {
       const target = api.config.esbuild?.target || ['es2015'];
       const optsMap = {
         [BundlerConfigType.csr]: {
-          target,
+const { target = 'es2015', pure } = api.config.esbuild || {};
           minify: true,
-          pure: api.config.esbuild?.pure,
+          target,
+          pure,
         },
         [BundlerConfigType.ssr]: {
           target: 'node10',

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -19,10 +19,9 @@ export default (api: IApi) => {
 
   api.modifyBundleConfig((memo, { type }) => {
     if (memo.optimization) {
-      const target = api.config.esbuild?.target || ['es2015'];
+      const { target = 'es2015', pure } = api.config.esbuild || {};
       const optsMap = {
         [BundlerConfigType.csr]: {
-const { target = 'es2015', pure } = api.config.esbuild || {};
           minify: true,
           target,
           pure,
@@ -30,7 +29,7 @@ const { target = 'es2015', pure } = api.config.esbuild || {};
         [BundlerConfigType.ssr]: {
           target: 'node10',
           minify: true,
-          pure: api.config.esbuild?.pure,
+          pure,
         },
       };
       const opts = optsMap[type] || optsMap[BundlerConfigType.csr];

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -24,10 +24,12 @@ export default (api: IApi) => {
         [BundlerConfigType.csr]: {
           target,
           minify: true,
+          pure: api.config.esbuild?.pure,
         },
         [BundlerConfigType.ssr]: {
           target: 'node10',
           minify: true,
+          pure: api.config.esbuild?.pure,
         },
       };
       const opts = optsMap[type] || optsMap[BundlerConfigType.csr];


### PR DESCRIPTION
[esbuild#pure](https://esbuild.github.io/api/#pure)

Support remove console.

```ts
export default {
  esbuild: {
    target: 'es5',
    pure: ['console.log'],
  },
};

```

## Related issues
+ [#7012](https://github.com/ant-design/ant-design-pro/issues/7012)
+ [#5266](https://github.com/ant-design/ant-design-pro/issues/5266)
+ [#3766](https://github.com/ant-design/ant-design-pro/issues/3766)
+ [#6540](https://github.com/ant-design/ant-design-pro/issues/6540)