### PR TITLE
feat: plugin dva support config immer.enableAllPlugins

### DIFF
--- a/packages/plugin-dva/src/dva.tpl
+++ b/packages/plugin-dva/src/dva.tpl
@@ -8,7 +8,7 @@ import { plugin, history } from '../core/umiExports';
 {{{ RegisterModelImports }}}
 {{ /LazyLoad }}
 {{ #dvaImmer }}
-import dvaImmer, { enableES5 } from '{{{ dvaImmerPath }}}';
+import dvaImmer, { enableES5, enableAllPlugins } from '{{{ dvaImmerPath }}}';
 {{ /dvaImmer }}
 
 let app:any = null;
@@ -38,6 +38,9 @@ export {{ #LazyLoad }}async {{ /LazyLoad }}function _onCreate(options = {}) {
   {{ #dvaImmerES5 }}
   enableES5();
   {{ /dvaImmerES5 }}
+  {{ #dvaImmerAllPlugins }}
+  enableAllPlugins();
+  {{ /dvaImmerAllPlugins }}
   (runtimeDva.plugins || []).forEach((plugin:any) => {
     app.use(plugin);
   });

--- a/packages/plugin-dva/src/index.ts
+++ b/packages/plugin-dva/src/index.ts
@@ -112,6 +112,9 @@ export default (api: IApi) => {
           dvaImmerES5:
             lodash.isPlainObject(api.config.dva?.immer) &&
             api.config.dva?.immer.enableES5,
+          dvaImmerAllPlugins:
+            lodash.isPlainObject(api.config.dva?.immer) &&
+            api.config.dva?.immer.enableAllPlugins,
           LazyLoad: api.config.dva?.lazyLoad,
           RegisterModelImports: models
             .map((path, index) => {


### PR DESCRIPTION
Was trying to use the mapset features of immer in my project, but got error that saying enableMapSet() need to be called when initializing the project. After further investigation, found out that enableAllPlugins is already exported from dva-immer but hasn't been supported to use in plugin-dva, so I made this change to resolve the issue I had. 
