### PR TITLE
feat(esbuild): apply userconfig targets to esbuild

### DIFF
--- a/packages/plugin-esbuild/src/fixtures/no-es5/.umirc.ts
+++ b/packages/plugin-esbuild/src/fixtures/no-es5/.umirc.ts
@@ -1,0 +1,22 @@
+
+export default {
+  nodeModulesTransform: {
+    type: 'none',
+  },
+  targets: {
+    ie: false,
+    edge:15,
+    chrome:51
+  },
+  history: {
+    type: 'memory',
+    options: {
+      initialEntries: ['/'],
+    },
+  },
+  mountElementId: '',
+  routes: [
+    { path: '/', component: 'index' },
+  ],
+  esbuild: {},
+}

--- a/packages/plugin-esbuild/src/fixtures/no-es5/src/pages/index.js
+++ b/packages/plugin-esbuild/src/fixtures/no-es5/src/pages/index.js
@@ -1,0 +1,3 @@
+export default () => {
+  throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")
+}

--- a/packages/plugin-esbuild/src/index.test.ts
+++ b/packages/plugin-esbuild/src/index.test.ts
@@ -30,7 +30,7 @@ describe('normal build', () => {
     expect(err).toBeFalsy();
     expect(existsSync(join(cwd, 'dist', 'umi.js'))).toBeTruthy();
     expect(readFileSync(join(cwd, 'dist', 'umi.js'), 'utf8')).toContain(
-      'new TypeError(`Invalid attempt to spread non-iterable',
+      'throw new TypeError("Invalid attempt to spread non-iterable instance',
     );
   });
 });
@@ -59,7 +59,36 @@ describe('es5 build', () => {
     expect(err).toBeFalsy();
     expect(existsSync(join(cwd, 'dist', 'umi.js'))).toBeTruthy();
     expect(readFileSync(join(cwd, 'dist', 'umi.js'), 'utf8')).toContain(
-      'new TypeError("Invalid attempt to spread non-iterable',
+      'throw new TypeError("Invalid attempt to spread non-iterable instance',
+    );
+  });
+});
+
+describe('no-es5 build', () => {
+  let err: any;
+  const cwd = join(fixtures, 'no-es5');
+  beforeAll(async () => {
+    const service = new Service({
+      cwd,
+      env: 'production',
+      plugins: [require.resolve('./index.ts')],
+    });
+    let err;
+    try {
+      await service.run({
+        name: 'build',
+      });
+    } catch (e) {
+      console.error('no-es5 build error', e);
+      err = true;
+    }
+  });
+
+  it('no-es5', () => {
+    expect(err).toBeFalsy();
+    expect(existsSync(join(cwd, 'dist', 'umi.js'))).toBeTruthy();
+    expect(readFileSync(join(cwd, 'dist', 'umi.js'), 'utf8')).toContain(
+      'new TypeError(`Invalid attempt to spread non-iterable',
     );
   });
 });

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -19,7 +19,34 @@ export default (api: IApi) => {
 
   api.modifyBundleConfig((memo, { type }) => {
     if (memo.optimization) {
-      const { target = 'es2015', pure } = api.config.esbuild || {};
+      const userConfigTargets = api.config.targets;
+      let defaultEsbuildTargets: string | string[] = 'es5';
+      function isTargetsES5() {
+        return (
+          userConfigTargets &&
+          (userConfigTargets.ie !== false ||
+            userConfigTargets.chrome < 51 ||
+            userConfigTargets.edge < 15 ||
+            userConfigTargets.ios < 10 ||
+            userConfigTargets.safari < 10 ||
+            userConfigTargets.firefox < 54)
+        );
+      }
+      if (!isTargetsES5()) {
+        userConfigTargets &&
+          Object.keys(userConfigTargets).forEach((key) => {
+            if (
+              key === 'node' ||
+              key === 'ie' ||
+              userConfigTargets[key] === false
+            )
+              return;
+            if (!Array.isArray(defaultEsbuildTargets))
+              defaultEsbuildTargets = [];
+            defaultEsbuildTargets.push(`${key}${userConfigTargets[key]}`);
+          });
+      }
+      const { target = defaultEsbuildTargets, pure } = api.config.esbuild || {};
       const optsMap = {
         [BundlerConfigType.csr]: {
           minify: true,


### PR DESCRIPTION
使用config里的targets自动配置ESBuildMinifyPlugin的target。

也算修复targets为ie时，esbuild默认target却是es2015，导致dist文件包含模板字符串报错的问题。

添加了no-es5的测试。其中测试normal和es5的结果不应是模板字符串，修改了。

fix umijs/umi#6359