### PR TITLE
fix(esbuild): rm pure setting & bump esbuild-loader to 2.9.2

### DIFF
--- a/packages/plugin-esbuild/package.json
+++ b/packages/plugin-esbuild/package.json
@@ -28,6 +28,6 @@
     "access": "public"
   },
   "dependencies": {
-    "esbuild-loader": "~2.6.3"
+    "esbuild-loader": "~2.9.2"
   }
 }

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -46,17 +46,15 @@ export default (api: IApi) => {
             defaultEsbuildTargets.push(`${key}${userConfigTargets[key]}`);
           });
       }
-      const { target = defaultEsbuildTargets, pure } = api.config.esbuild || {};
+      const { target = defaultEsbuildTargets } = api.config.esbuild || {};
       const optsMap = {
         [BundlerConfigType.csr]: {
           minify: true,
           target,
-          pure,
         },
         [BundlerConfigType.ssr]: {
           target: 'node10',
           minify: true,
-          pure,
         },
       };
       const opts = optsMap[type] || optsMap[BundlerConfigType.csr];


### PR DESCRIPTION
esbuild-loader不支持pure设置字段。
升级到2.9.2是因为2.10.0之后ESBuildPlugin被deprecated，build的时候有个提示log不太好看。

umijs/umi#6422