### PR TITLE
尝试修复嵌入主应用的子应用的热更新问题

### DIFF
--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -138,11 +138,24 @@ export default function (api: IApi) {
         '{ genMount as qiankun_genMount, genBootstrap as qiankun_genBootstrap, genUnmount as qiankun_genUnmount, genUpdate as qiankun_genUpdate }',
     };
   });
+
+  api.addEntryCodeAhead(
+    () =>
+      `
+    const appId = window.proxy.appId = 'appId' in window.proxy ? window.proxy.appId + 1 : 0;
+    try {
+      pluginArgs.appId = appId
+    } catch {
+      console.error(\`plugin-qiankun: Cannot find pluginArgs object in current scope, please check if the umijs version is greater than xxx\`)
+    }
+      `,
+  );
+
   api.addEntryCode(
     () =>
       `
     export const bootstrap = qiankun_genBootstrap(clientRender);
-    export const mount = qiankun_genMount('${api.config.mountElementId}');
+    export const mount = qiankun_genMount('${api.config.mountElementId}', appId);
     export const unmount = qiankun_genUnmount('${api.config.mountElementId}');
     export const update = qiankun_genUpdate();
 

--- a/packages/plugin-qiankun/src/slave/index.ts
+++ b/packages/plugin-qiankun/src/slave/index.ts
@@ -144,9 +144,9 @@ export default function (api: IApi) {
       `
     const appId = window.proxy.appId = 'appId' in window.proxy ? window.proxy.appId + 1 : 0;
     try {
-      pluginArgs.appId = appId
+      pluginArgs.appId = appId;
     } catch {
-      console.error(\`plugin-qiankun: Cannot find pluginArgs object in current scope, please check if the umijs version is greater than xxx\`)
+      console.error(\`plugin-qiankun: Cannot find pluginArgs object in current scope, please check if the umijs version is greater than xxx\`);
     }
       `,
   );

--- a/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/lifecycles.ts.tpl
@@ -23,7 +23,11 @@ let render = noop;
 let hasMountedAtLeastOnce = false;
 
 export default () => defer.promise;
-export const clientRenderOptsStack: any[] = [];
+
+const clientRenderOptsMap: any = {};
+export function getClientRenderOpts(appId: number) {
+  return { ...clientRenderOptsMap[appId] };
+}
 
 function normalizeHistory(
   history?: 'string' | Record<string, any>,
@@ -64,7 +68,7 @@ export function genBootstrap(oldRender: typeof noop) {
   };
 }
 
-export function genMount(mountElementId: string) {
+export function genMount(mountElementId: string, appId: number) {
   return async (props?: any) => {
     // props 有值时说明应用是通过 lifecycle 被主应用唤醒的，而不是独立运行时自己 mount
     if (typeof props !== 'undefined') {
@@ -108,7 +112,7 @@ export function genMount(mountElementId: string) {
         },
       };
 
-      clientRenderOptsStack.push(clientRenderOpts);
+      clientRenderOptsMap[appId] = clientRenderOpts;
     }
 
     // 第一次 mount defer 被 resolve 后umi 会自动触发 render，非第一次 mount 则需手动触发

--- a/packages/plugin-qiankun/src/slave/slaveRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/slave/slaveRuntimePlugin.ts.tpl
@@ -1,5 +1,5 @@
 import React from 'react';
-import qiankunRender, { clientRenderOptsStack } from './lifecycles';
+import qiankunRender, { getClientRenderOpts } from './lifecycles';
 
 export function rootContainer(container: HTMLElement) {
   const value =
@@ -13,9 +13,9 @@ export const render = (oldRender: any) => {
   return qiankunRender().then(oldRender);
 };
 
-export function modifyClientRenderOpts(memo: any) {
-  // 每次应用 render 的时候会调 modifyClientRenderOpts，这时尝试从队列中取 render 的配置
-  const clientRenderOpts = clientRenderOptsStack.shift();
+export function modifyClientRenderOpts(memo: any, args: any) {
+  // 每次应用 render 的时候会调 modifyClientRenderOpts，这时根据当前的appId获取 render 的配置
+  const clientRenderOpts = getClientRenderOpts(args.appId);
   if (clientRenderOpts) {
     const history = clientRenderOpts.getHistory();
     delete clientRenderOpts.getHistory;


### PR DESCRIPTION
当前问题在于, 在 [#418](https://github.com/umijs/plugins/pull/418) 中, 将clientRenderOpts改为clientRenderOptsStack, 并以pop的方式获取, 这样有两个问题:
    
    1. 当热更新时, 由于已经pop过, 此时clientRenderOptsStack为空, 那么src中生成的`.umi/umi.ts`的modifyClientRenderOpts操作将无法修改rootElement为dom, 而是保持为string.
       这就导致热更新时, 直接把子应用挂载到了string类型的rootElement对应的dom上, 也就是最外层的那个root, 就相当于子应用把主应用覆盖了.
    
    2. 在 [#423](https://github.com/umijs/plugins/pull/423) 讲到, mount顺序是一定的, 但是render不是. 又因为上述pop过程是在render过程中进行的, 那么这个pop的顺序也不一定是安全的.
       这里使用appId的方式来保证render和clientRenderOpts的一致性.