### PR TITLE
fix(plugin-locale): default antd locale use esm

### DIFF
--- a/packages/plugin-locale/src/index.ts
+++ b/packages/plugin-locale/src/index.ts
@@ -146,10 +146,16 @@ export default (api: IApi) => {
       );
     }
 
+    const NormalizeAntdLocalesName = function () {
+      // @ts-ignore
+      return this.replace(/\//g, '_');
+    };
+
     api.writeTmpFile({
       content: Mustache.render(localeTpl, {
         MomentLocales,
         DefaultMomentLocale,
+        NormalizeAntdLocalesName,
         DefaultAntdLocales,
         Antd: !!antd,
         Title: title && api.config.title,

--- a/packages/plugin-locale/src/templates/locale.tpl
+++ b/packages/plugin-locale/src/templates/locale.tpl
@@ -12,6 +12,10 @@ import 'moment/locale/{{.}}';
 {{/MomentLocales.length}}
 import { RawIntlProvider, getLocale, getDirection , setIntl, getIntl, localeInfo } from './localeExports';
 
+{{#DefaultAntdLocales}}
+import {{NormalizeAntdLocalesName}} from '{{{.}}}';
+{{/DefaultAntdLocales}}
+
 // @ts-ignore
 export const event = new EventEmitter();
 event.setMaxListeners(5);
@@ -64,13 +68,13 @@ export const _LocaleContainer = (props:any) => {
   {{#Antd}}
   const defaultAntdLocale = {
     {{#DefaultAntdLocales}}
-    ...require('{{{.}}}').default,
+    ...{{NormalizeAntdLocalesName}},
     {{/DefaultAntdLocales}}
   }
-  const direcition = getDirection();
+  const direction = getDirection();
 
   return (
-    <ConfigProvider  direction={direcition} locale={localeInfo[locale]?.antd || defaultAntdLocale}>
+    <ConfigProvider  direction={direction} locale={localeInfo[locale]?.antd || defaultAntdLocale}>
       <RawIntlProvider value={intl}>{props.children}</RawIntlProvider>
     </ConfigProvider>
   )


### PR DESCRIPTION
https://github.com/umijs/plugins/blob/2b2c169/packages/plugin-locale/src/templates/locale.tpl#L67