### PR TITLE
fix(preset-umi2-compatible): 支持 mfsu

### DIFF
--- a/packages/preset-umi2-compatible/src/plugins/router/router.ts
+++ b/packages/preset-umi2-compatible/src/plugins/router/router.ts
@@ -7,7 +7,7 @@ export default (api: IApi) => {
         source: require.resolve(
           '../../../src/plugins/router/historyAdapater.ts',
         ),
-        exportAll: true,
+        specifiers: ['push', 'replace', 'go', 'goBack', 'goForward'],
       },
     ];
   });


### PR DESCRIPTION
目前mfsu还不支持自动处理export *导出 ,   [#6922](https://github.com/umijs/umi/issues/6922) 。

router 不支持导出 : [umijs](https://github.com/umijs/umi/blob/master/packages/preset-built-in/src/plugins/generateFiles/core/umiExports.ts#L11)