### PR TITLE
[BUG]fixed plugin-openapi ui not work when only one openAPI

### DIFF
--- a/packages/plugin-openapi/src/index.ts
+++ b/packages/plugin-openapi/src/index.ts
@@ -55,7 +55,7 @@ import SwaggerUI from "swagger-ui-react";
 import "swagger-ui-react/swagger-ui.css";
 
 const App = () => {
-  const [value, setValue] = useState("openapi");
+  const [value, setValue] = useState("${arrayConfig.length === 0 ? 'openapi' : arrayConfig[0].projectName}");
   return (
     <div
       style={{


### PR DESCRIPTION
when only one openAPI, the dropdown list can't work, and ui can't show the correct openapi.json.

![深度截图_选择区域_20210722174754](https://user-images.githubusercontent.com/4010613/126620560-fd4a089b-a3b5-4caa-9093-356d343be1a9.png)
