### PR TITLE
fix(qiankun): 允许 qiankun pacthRoute 时 routes 为空数组

### DIFF
--- a/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
@@ -86,7 +86,7 @@ export function patchRoutes(opts: { routes: IRouteProps[] }) {
       const rootRoute = routes.find(route => route.path === '/');
       if (rootRoute) {
         // 如果根路由是叶子节点，则直接返回其父节点
-        if (!rootRoute.routes?.length) {
+        if (!rootRoute.routes) {
           return routes;
         }
 


### PR DESCRIPTION
```js
{
  routes: [
    {
      path: '/',
      component: '@/layouts/index',
      routes: [],
    },
  ],
}
```

当 '/' 配置了 routes 是空数组的时候，注入的路由改为注入到 routes 中而不是根路由