### PR TITLE
feat: del addProjectFirstLibraries

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -70,21 +70,6 @@ export default (api: IApi) => {
     });
   }
 
-  api.addProjectFirstLibraries(() => {
-    const imps = [
-      {
-        name: 'antd',
-        path: dirname(require.resolve('antd/package.json')),
-      },
-    ];
-    if (mobile) {
-      imps.push({
-        name: 'antd-mobile',
-        path: dirname(require.resolve('antd-mobile/package.json')),
-      });
-    }
-    return imps;
-  });
   if (opts?.config) {
     api.onGenerateFiles({
       fn() {


### PR DESCRIPTION
如果我项目依赖的是antd4.x，同时引入一个my-antd库，my-antd是基于antd3.x封装的。
由于alias antd为node_modules下面的antd包，导致my-antd内部引入的antd组件也是alias后的antd4.x。

比如：my-antd 内部有个组件使用 import { Form } from 'antd'; Form.create(); 会报错 create is not function（此时的antd是4.x版本）。

虽然 my-antd 下面的node_modules里面有antd3.x版本，但此时里面引入的依然是alias后的antd4.x版本。