### PR TITLE
feat: 支持运行时配置嵌套的路由关联微应用

### DIFF
--- a/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
@@ -54,7 +54,14 @@ function patchMicroAppRouteComponent(routes: IRouteProps[]) {
     const { routeBindingAlias, base, masterHistoryType } = getMasterOptions() as MasterOptions;
     const microAppAttachedRoutes = microAppRuntimeRoutes.filter(r => !r.insert);
     microAppAttachedRoutes.reverse().forEach(microAppRoute => {
-      patchMicroAppRoute(microAppRoute, getMicroAppRouteComponent, { base, masterHistoryType, routeBindingAlias });
+      const patchRoute = (route: IRouteProps) => {
+        patchMicroAppRoute(route, getMicroAppRouteComponent, { base, masterHistoryType, routeBindingAlias });
+        if (route.routes?.length) {
+          route.routes.forEach(patchRoute);
+        }
+      };
+
+      patchRoute(microAppRoute);
       rootRoutes.unshift(microAppRoute);
     });
   }


### PR DESCRIPTION
比如运行时路由配置的是：
```diff
routes: [
  { path: '/app1', microApp: 'app1' },
+ { path: '/app2', routes: [
+   { path: '/app2/nest', microApp: 'app2' }
+ ] },
]
```