### PR TITLE
feat: No verification of lang-key

### DIFF
--- a/packages/plugin-locale/src/templates/localeExports.tpl
+++ b/packages/plugin-locale/src/templates/localeExports.tpl
@@ -194,8 +194,6 @@ export const getDirection = () => {
  * @returns string
  */
 export const setLocale = (lang: string, realReload: boolean = true) => {
-  const localeExp = new RegExp(`^([a-z]{2}){{BaseSeparator}}?([A-Z]{2})?$`);
-
   const runtimeLocale = plugin.applyPlugins({
     key: 'locale',
     type: ApplyPluginsType.modify,
@@ -203,10 +201,6 @@ export const setLocale = (lang: string, realReload: boolean = true) => {
   });
 
   const updater = () => {
-    if (lang !== undefined && !localeExp.test(lang)) {
-      // for reset when lang === undefined
-      throw new Error('setLocale lang format error');
-    }
     if (getLocale() !== lang) {
       if (typeof window.localStorage !== 'undefined' && useLocalStorage) {
         window.localStorage.setItem('umi_locale', lang || '');


### PR DESCRIPTION
### 修改点

去掉 setLocale的语言key 的正则校验

### 原因

通过 [addLocale](https://umijs.org/zh-CN/plugins/plugin-locale#addlocale) 动态添加语言，
但无法通过 [setLocale](https://umijs.org/zh-CN/plugins/plugin-locale#setlocale) 无法使用，因为 setLocale 对语言的  key 做检验。

目前的  lang key的定义 其实是多样化的，比如 zh-Hant、zh-Hans ....

```
  {
      "iso_code":"zh-Hant",
      "alt_name":"zh-Hant",
      "name":"Chinese Traditional",
      "id":2
  },
    {
      "iso_code":"zh-Hans",
      "alt_name":"zh-Hans",
      "name":"Chinese Simplified",
      "id":5
  },
```