### PR TITLE
fix(qiankun): 运行时同时支持insert路径写入，以及嵌套路径两种写入方式 (#751)

### DIFF
--- a/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
@@ -29,9 +29,14 @@ async function getMasterRuntime() {
 
 // modify route with "microApp" attribute to use real component
 function patchMicroAppRouteComponent(routes: IRouteProps[]) {
+  const { routeBindingAlias, base, masterHistoryType } = getMasterOptions() as MasterOptions;
+
   const insertRoutes = microAppRuntimeRoutes.filter(r => r.insert);
   // 先处理 insert 配置
   insertRoutes.forEach(route => {
+    // 转化insert配置变更成 micro组件
+    patchMicroAppRoute(route, getMicroAppRouteComponent, { base, masterHistoryType, routeBindingAlias });
+    // 将转换后的micro组件，插入对应路由
     insertRoute(routes, route);
   });
 
@@ -51,7 +56,6 @@ function patchMicroAppRouteComponent(routes: IRouteProps[]) {
 
   const rootRoutes = getRootRoutes(routes);
   if (rootRoutes) {
-    const { routeBindingAlias, base, masterHistoryType } = getMasterOptions() as MasterOptions;
     const microAppAttachedRoutes = microAppRuntimeRoutes.filter(r => !r.insert);
     microAppAttachedRoutes.reverse().forEach(microAppRoute => {
       const patchRoute = (route: IRouteProps) => {


### PR DESCRIPTION
umi-qiankun@2.30.0 [umijs#698](https://github.com/umijs/plugins/pull/698)
版本支持运行中 insert 路由，加载微应用

```
export const qiankun = {
  apps: [{
      name: 'demo',
      entry: "https://localhost:8001"
 }],
  routes: [
    {
      path: '/test/demo',
      microApp: 'demo',
      // 通过insert可以在运行时插入主系统的routes中
      insert: '/test'
    },
};
```

但是到了
umi-qiankun@2.33.0 [umijs#706](https://github.com/umijs/plugins/pull/706)

insert 只能插入路由，而不能加载微引用

插入路由是通过 加载嵌套路由的方式加载微应用

```
export const qiankun = {
  apps: [{
      name: 'demo',
      entry: "https://localhost:8001"
 }],
  routes: [
    { path: '/test',
        routes: [
           { path: '/test/demo', microApp: 'demo' }
        ] 
     },
  ]
};
```

目的：最好两种方式都能加载微应用，可以让用户自定义选择那种模式

个人理解的使用场景：

insert： 模式比较适合，主应用为主体，路由大部分在配置中，只有小部分做微应用的时候适合独立插入路由。

嵌套路由：模式比较舍和，主应用只是一个基础的载体，所有的业务功能都来自子应用。主应用的路由是通过动态加载的方式生成





