### PR TITLE
feat: BizError返回request

### DIFF
--- a/packages/plugin-request/src/request.ts
+++ b/packages/plugin-request/src/request.ts
@@ -228,6 +228,7 @@ const getRequestMethod = () => {
       error.name = 'BizError';
       error.data = resData;
       error.info = errorInfo;
+      error.request = req;
       error.response = res;
       throw error;
     }


### PR DESCRIPTION
plugin-request插件BizError时需要返回request，以便做一些接口的错误监控和埋点上报