### PR TITLE
fix: allow config for babel-plugin-import

### DIFF
--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -6,11 +6,24 @@ import semver from 'semver';
 
 const { Mustache } = utils;
 
+// allow config for babel-plugin-import
+interface ImportConfig {
+  libraryName?: string
+  libraryDirectory?: string
+  style?: string | boolean | (name: string, file: Object) => string | boolean
+  camel2DashComponentName?: boolean
+  styleLibraryDirectory?: string
+  customName?: (name: string, file: Object) => string
+  customStyleName?: (name: string, file: Object) => string
+  transformToDefaultImport?: boolean
+}
+
 interface IAntdOpts {
   dark?: boolean;
   compact?: boolean;
   disableBabelPluginImport?: boolean;
   config?: ConfigProviderProps;
+  import?: ImportConfig[]
 }
 
 export default (api: IApi) => {
@@ -39,7 +52,7 @@ export default (api: IApi) => {
     }
     return {
       ...opts,
-      import: (opts.import || []).concat(imps),
+      import: (opts?.import || []).concat(imps),
     };
   });
 

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -37,6 +37,7 @@ export default (api: IApi) => {
           compact: joi.boolean(),
           disableBabelPluginImport: joi.boolean(),
           config: joi.object(),
+          import: joi.array()
         });
       },
     },

--- a/packages/plugin-antd/src/index.ts
+++ b/packages/plugin-antd/src/index.ts
@@ -10,7 +10,7 @@ const { Mustache } = utils;
 interface ImportConfig {
   libraryName?: string
   libraryDirectory?: string
-  style?: string | boolean | (name: string, file: Object) => string | boolean
+  style?: string | boolean | ((name: string, file: Object) => string | boolean)
   camel2DashComponentName?: boolean
   styleLibraryDirectory?: string
   customName?: (name: string, file: Object) => string


### PR DESCRIPTION
'import' config is available in code but 'import' type is lost in interface.