### PR TITLE
fix(preset-react): 修复 modifyDefaultConfig 覆盖了配置问题

### DIFF
--- a/packages/preset-react/src/defaultConfig.ts
+++ b/packages/preset-react/src/defaultConfig.ts
@@ -3,13 +3,12 @@ import { IApi, IConfig } from '@umijs/types';
 export default (api: IApi) => {
   const defaultOptions = {
     access: {},
-    ...api.userConfig,
   } as IConfig;
 
   api.modifyDefaultConfig((memo) => {
     return {
-      ...memo,
       ...defaultOptions,
+      ...memo,
     };
   });
 };


### PR DESCRIPTION
这段代码会导致在用户仅设置了某个插件的个别配置后，该插件的所有默认配置都失效

```ts
import { IApi, IConfig } from '@umijs/types';

export default (api: IApi) => {
  const defaultOptions = {
    access: {},
    ...api.userConfig,
  } as IConfig;

  api.modifyDefaultConfig((memo) => {
    return {
      ...memo,
      ...defaultOptions, // 此操作会覆盖掉已 merge 的 config，强行使用 userConfig
    };
  });
};
```