### PR TITLE
feat(locale): 完善 RTL 支持

### DIFF
--- a/packages/plugin-locale/src/templates/SelectLang.tpl
+++ b/packages/plugin-locale/src/templates/SelectLang.tpl
@@ -1,6 +1,6 @@
-import React,{ useState } from 'react';
+import React, { useContext, useState } from 'react';
 {{#Antd}}
-import { Menu, Dropdown } from 'antd';
+import { Menu, Dropdown, ConfigProvider } from 'antd';
 import { ClickParam } from 'antd/{{{antdFiles}}}/menu';
 import { DropDownProps } from 'antd/{{{antdFiles}}}/dropdown';
 {{/Antd}}
@@ -396,6 +396,7 @@ export const SelectLang: React.FC<SelectLangProps> = (props) => {
   reload,
   ...restProps
 } = props;
+  const { direction } = useContext(ConfigProvider.ConfigContext);
   const [selectedLang, setSelectedLang] = useState(() => getLocale());
 
   const changeLang = ({ key }: ClickParam): void => {
@@ -449,7 +450,7 @@ export const SelectLang: React.FC<SelectLangProps> = (props) => {
   };
 
   return (
-    <HeaderDropdown overlay={langMenu} placement="bottomRight" {...restProps}>
+    <HeaderDropdown overlay={langMenu} placement={direction !== 'rtl' ? 'bottomRight' : 'bottomLeft'} {...restProps}>
       <span className={globalIconClassName} style={inlineStyle}>
         <i className="anticon" title={allLangUIConfig[selectedLang]?.title}>
           { icon ?


### PR DESCRIPTION
Dropdown 的 placement 参数，在 RTL 时, bottomRight 其实并不会自动显示成 bottomLeft。

![image](https://user-images.githubusercontent.com/28819315/157656203-cb0f53ac-824e-400c-b232-db03827dd1e3.png)

原来没有问题，是因为有 [autoAdjustOverflow](https://github.com/ant-design/ant-design/commit/235ab32f44d9594c59e00bff5bd114ad3e49d456) 选项，但是如果显示不溢出的话，这个 dropdown 的位置仍然是错的。

因为 autoAdjustOverflow 似乎在 antd 4.17 后的某个版本被关闭了(master 分支已经加回去了 https://github.com/ant-design/ant-design/commit/235ab32f44d9594c59e00bff5bd114ad3e49d456 )，所以暴露了这个问题。
