### PR TITLE
fix(plugin-dva|plugin-locale): fix addRuntimePlugin use absolute path

### DIFF
--- a/packages/plugin-dva/src/index.ts
+++ b/packages/plugin-dva/src/index.ts
@@ -227,9 +227,7 @@ app.model({ namespace: '${basename(path, extname(path))}', ...Model${lodash.uppe
   });
 
   // Runtime Plugin
-  api.addRuntimePlugin(() =>
-    hasModels ? [join(api.paths.absTmpPath!, 'plugin-dva/runtime.tsx')] : [],
-  );
+  api.addRuntimePlugin(() => (hasModels ? ['../plugin-dva/runtime.tsx'] : []));
   api.addRuntimePluginKey(() => (hasModels ? ['dva'] : []));
 
   // 导出内容

--- a/packages/plugin-locale/src/index.ts
+++ b/packages/plugin-locale/src/index.ts
@@ -229,9 +229,7 @@ export default (api: IApi) => {
   });
 
   // Runtime Plugin
-  api.addRuntimePlugin(() =>
-    join(paths.absTmpPath!, 'plugin-locale/runtime.tsx'),
-  );
+  api.addRuntimePlugin(() => '../plugin-locale/runtime.tsx');
 
   // Modify entry js
   api.addEntryCodeAhead(() =>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- close https://github.com/umijs/umi/issues/7000

解决了打包产物包含绝对路径的问题，我在app.ts和 plugin-dva遇到了，然后在issue里发现还有已知的plugin-locale
plugin-dva和plugin-locale在这个MR解决，另外两个在umi的仓库提交PR解决https://github.com/umijs/umi/pull/7983

