### PR TITLE
fix(plugin-layout):修复layout插件在声明isUrl的菜单项时可点击区域过窄的问题

### DIFF
--- a/packages/plugin-layout/src/layout/index.tsx.tpl
+++ b/packages/plugin-layout/src/layout/index.tsx.tpl
@@ -79,7 +79,11 @@ const BasicLayout = (props: any) => {
       logo={logo}
       menuItemRender={(menuItemProps, defaultDom) => {
         if (menuItemProps.isUrl) {
-          return defaultDom;
+          return (
+            <a href={menuItemProps.path} target="_blank">
+              {defaultDom}
+            </a>
+          );
         }
         if (menuItemProps.path && location.pathname !== menuItemProps.path) {
           return (


### PR DESCRIPTION
antd-pro的layout为mix的场景下，如果二级菜单项的Link为外链url，那么此时的鼠标可点击跳转的范围会变窄，正常情况下点击菜单项的一行都可以跳转但是此情况下必须点击文字上才可以完成跳转动作


https://user-images.githubusercontent.com/19668821/172044175-de68b3ed-9add-417f-9ea1-5823af4e1b18.mp4



