### PR TITLE
fix(layout): root-entry-name variable error

### DIFF
--- a/packages/plugin-layout/src/index.ts
+++ b/packages/plugin-layout/src/index.ts
@@ -118,6 +118,13 @@ export default (api: IApi) => {
   api.modifyDefaultConfig((config) => {
     // @ts-ignore
     config.title = false;
+    
+    // layout/style.less 依赖 antd 的变量表，此处注入预置 less 变量
+    // 用于兼容 antd@4.17.0 后的版本，因为 es/style/themes/default.less 依赖 @root-entry-name
+    // 不直接用 dist/antd.variable.less 是为了兼容之前的版本
+    config.theme ??= {};
+    config.theme['root-entry-name'] = 'variable';
+    
     return config;
   });
 

--- a/packages/plugin-layout/src/index.ts
+++ b/packages/plugin-layout/src/index.ts
@@ -118,13 +118,6 @@ export default (api: IApi) => {
   api.modifyDefaultConfig((config) => {
     // @ts-ignore
     config.title = false;
-    
-    // layout/style.less 依赖 antd 的变量表，此处注入预置 less 变量
-    // 用于兼容 antd@4.17.0 后的版本，因为 es/style/themes/default.less 依赖 @root-entry-name
-    // 不直接用 dist/antd.variable.less 是为了兼容之前的版本
-    config.theme ??= {};
-    config.theme['root-entry-name'] = 'variable';
-    
     return config;
   });
 

--- a/packages/plugin-layout/src/layout/style.less
+++ b/packages/plugin-layout/src/layout/style.less
@@ -1,4 +1,4 @@
-@import (reference) '~antd/es/style/themes/index';
+@import (reference) '~antd/dist/antd.less';
 
 @pro-header-hover-bg: rgba(0, 0, 0, 0.025);
 


### PR DESCRIPTION
## Description

更新 `style/index.less` 中引入 antd 默认主题变量的方式，避免报错：

```bash
Compile Error ：“Variable @root-entry-name is undefined”
```

ref: https://github.com/ant-design/ant-design/issues/33853