### PR TITLE
fix(plugin-qiankun): fixed pnpm installation dependency error

### DIFF
--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -9,9 +9,9 @@ import {
   HashHistoryBuildOptions,
   MemoryHistoryBuildOptions,
 } from "history-with-query";
-import concat from "{{{ lodashConcatPath }}}";
-import mergeWith from "{{{ lodashMergeWithPath }}}";
-import noop from "{{{ lodashNoopPath }}}";
+import concat from "{{{ lodashPath }}}/concat";
+import mergeWith from "{{{ lodashPath }}}/mergeWith";
+import noop from "{{{ lodashPath }}}/noop";
 import {
   FrameworkConfiguration,
   loadMicroApp,

--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -9,15 +9,15 @@ import {
   HashHistoryBuildOptions,
   MemoryHistoryBuildOptions,
 } from "history-with-query";
-import concat from "lodash/concat";
-import mergeWith from "lodash/mergeWith";
-import noop from "lodash/noop";
+import concat from "{{{ lodashConcatPath }}}";
+import mergeWith from "{{{ lodashMergeWithPath }}}";
+import noop from "{{{ lodashNoopPath }}}";
 import {
   FrameworkConfiguration,
   loadMicroApp,
   MicroApp as MicroAppType,
   prefetchApps,
-} from "qiankun";
+} from "{{{ qiankunPath }}}";
 import React, {
   forwardRef,
   Ref,
@@ -257,10 +257,12 @@ export const MicroApp = forwardRef(
       (propsFromParams.autoSetLoading
         ? (loading) => <MicroAppLoader loading={loading} />
         : null);
+    
+    const wrapperStyle = { position: "relative" }
 
     return Boolean(microAppLoader) || Boolean(microAppErrorBoundary) ? (
       <div
-        style={{ position: "relative" }}
+        style={wrapperStyle}
         className={`${wrapperClassName || ''} qiankun-micro-app`}
       >
         {Boolean(microAppLoader) && microAppLoader(loading)}

--- a/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
+++ b/packages/plugin-qiankun/src/master/MicroApp.tsx.tpl
@@ -258,7 +258,7 @@ export const MicroApp = forwardRef(
         ? (loading) => <MicroAppLoader loading={loading} />
         : null);
     
-    const wrapperStyle = { position: "relative" }
+    const wrapperStyle = { position: "relative" };
 
     return Boolean(microAppLoader) || Boolean(microAppErrorBoundary) ? (
       <div

--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -94,7 +94,15 @@ export default function (api: IApi) {
 
     api.writeTmpFile({
       path: 'plugin-qiankun/MicroApp.tsx',
-      content: readFileSync(join(__dirname, 'MicroApp.tsx.tpl'), 'utf-8'),
+      content: utils.Mustache.render(
+        readFileSync(join(__dirname, 'MicroApp.tsx.tpl'), 'utf-8'),
+        {
+          lodashConcatPath: winPath(require.resolve('lodash/concat')),
+          lodashMergeWithPath: winPath(require.resolve('lodash/mergeWith')),
+          lodashNoopPath: winPath(require.resolve('lodash/noop')),
+          qiankunPath: winPath(require.resolve('qiankun')),
+        },
+      ),
     });
 
     api.writeTmpFile({
@@ -107,15 +115,21 @@ export default function (api: IApi) {
 
     api.writeTmpFile({
       path: 'plugin-qiankun/masterRuntimePlugin.ts',
-      content: readFileSync(
-        join(__dirname, 'masterRuntimePlugin.ts.tpl'),
-        'utf-8',
+      content: utils.Mustache.render(
+        readFileSync(join(__dirname, 'masterRuntimePlugin.ts.tpl'), 'utf-8'),
+        {
+          qiankunPath: winPath(require.resolve('qiankun')),
+        },
       ),
     });
 
+    const pathToRegexpPath = winPath(require.resolve('path-to-regexp'));
     api.writeTmpFile({
       path: 'plugin-qiankun/common.ts',
-      content: readFileSync(join(__dirname, '../../src/common.ts'), 'utf-8'),
+      content: readFileSync(
+        join(__dirname, '../../src/common.ts'),
+        'utf-8',
+      ).replace(/path-to-regexp/g, pathToRegexpPath),
     });
     api.writeTmpFile({
       path: 'plugin-qiankun/constants.ts',

--- a/packages/plugin-qiankun/src/master/index.ts
+++ b/packages/plugin-qiankun/src/master/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable quotes */
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 // eslint-disable-next-line import/no-unresolved
 import { IApi, utils } from 'umi';
 import {
@@ -78,6 +78,9 @@ export default function (api: IApi) {
     const { master: options } = api.config?.qiankun || {};
     const masterHistoryType = (history && history?.type) || defaultHistoryType;
     const base = api.config.base || '/';
+    const qiankunPath = api.config.externals?.qiankun
+      ? 'qiankun'
+      : winPath(dirname(require.resolve('qiankun/package')));
 
     api.writeTmpFile({
       path: 'plugin-qiankun/masterOptions.js',
@@ -97,10 +100,8 @@ export default function (api: IApi) {
       content: utils.Mustache.render(
         readFileSync(join(__dirname, 'MicroApp.tsx.tpl'), 'utf-8'),
         {
-          lodashConcatPath: winPath(require.resolve('lodash/concat')),
-          lodashMergeWithPath: winPath(require.resolve('lodash/mergeWith')),
-          lodashNoopPath: winPath(require.resolve('lodash/noop')),
-          qiankunPath: winPath(require.resolve('qiankun')),
+          lodashPath: winPath(dirname(require.resolve('lodash/package'))),
+          qiankunPath,
         },
       ),
     });
@@ -118,12 +119,14 @@ export default function (api: IApi) {
       content: utils.Mustache.render(
         readFileSync(join(__dirname, 'masterRuntimePlugin.ts.tpl'), 'utf-8'),
         {
-          qiankunPath: winPath(require.resolve('qiankun')),
+          qiankunPath,
         },
       ),
     });
 
-    const pathToRegexpPath = winPath(require.resolve('path-to-regexp'));
+    const pathToRegexpPath = winPath(
+      dirname(require.resolve('path-to-regexp/package')),
+    );
     api.writeTmpFile({
       path: 'plugin-qiankun/common.ts',
       content: readFileSync(

--- a/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
+++ b/packages/plugin-qiankun/src/master/masterRuntimePlugin.ts.tpl
@@ -3,7 +3,7 @@
 import '@@/plugin-qiankun/qiankunRootExports.js';
 import { IRouteProps, BaseIConfig } from '@umijs/types';
 import assert from 'assert';
-import { prefetchApps, registerMicroApps, start } from 'qiankun';
+import { prefetchApps, registerMicroApps, start } from '{{{ qiankunPath }}}';
 // @ts-ignore
 import { ApplyPluginsType, getMicroAppRouteComponent, plugin } from 'umi';
 


### PR DESCRIPTION
修复 使用 pnpm 安装 umi 依赖，项目启动时，.umi 目录下，plugin-qiankun 的临时文件部分依赖找不到
[#issues](https://github.com/umijs/umi/issues/8148)