### PR TITLE
修复minify导致的语法命名冲突问题

### DIFF
--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -11,6 +11,10 @@ export default (api: IApi) => {
             joi.string(),
             joi.array().items(joi.string()),
           ),
+          format: joi.alternatives(
+            joi.string(),
+            joi.array().items(joi.string()),
+          ),
         });
       },
     },

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -19,11 +19,12 @@ export default (api: IApi) => {
 
   api.modifyBundleConfig((memo, { type }) => {
     if (memo.optimization) {
-      const { target = 'es2015' } = api.config.esbuild || {};
+      const { target = 'es2015', format } = api.config.esbuild || {};
       const optsMap = {
         [BundlerConfigType.csr]: {
           minify: true,
           target,
+          format
         },
         [BundlerConfigType.ssr]: {
           target: 'node10',

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -12,8 +12,7 @@ export default (api: IApi) => {
             joi.array().items(joi.string()),
           ),
           format: joi.alternatives(
-             joi.string().valid('iife', 'cjs', 'esm')
-             joi.array().items(joi.string()),
+             joi.string().valid('iife', 'cjs', 'esm'),
           ),
         });
       },

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -28,7 +28,7 @@ export default (api: IApi) => {
         [BundlerConfigType.csr]: {
           minify: true,
           target,
-          format
+          format,
         },
         [BundlerConfigType.ssr]: {
           target: 'node10',

--- a/packages/plugin-esbuild/src/index.ts
+++ b/packages/plugin-esbuild/src/index.ts
@@ -12,8 +12,8 @@ export default (api: IApi) => {
             joi.array().items(joi.string()),
           ),
           format: joi.alternatives(
-            joi.string(),
-            joi.array().items(joi.string()),
+             joi.string().valid('iife', 'cjs', 'esm')
+             joi.array().items(joi.string()),
           ),
         });
       },


### PR DESCRIPTION
修复 esbuildminifyplugin  压缩导致的async，spread语法被作为全局变量设置到window上而引起的重复问题

![image](https://user-images.githubusercontent.com/16741847/192681583-3fda874a-405c-4445-9427-a368e761ccd2.png)
