### PR TITLE
 支持用户关闭abort弹窗

### DIFF
--- a/packages/plugin-request/src/request.ts
+++ b/packages/plugin-request/src/request.ts
@@ -166,6 +166,11 @@ const getRequestMethod = () => {
       }
       errorInfo = error.info;
 
+      // skipUserAbortError == true && showType = 0, you can close message by default, and no side effect for other errors, it's necessary for user abort requests.
+      if (error.name === 'AbortError' && error?.request?.options?.skipUserAbortError) {
+        errorInfo = errorAdaptor(error.name);
+      }
+
       if (errorInfo) {
         const errorMessage = errorInfo?.errorMessage;
         const errorCode = errorInfo?.errorCode;


### PR DESCRIPTION
 通过 skipUserAbortError 和 adaptor 控制是否关闭被 abort 掉的接口请求报错. 通常情况下不应该显示错误提示.