### PR TITLE
feat: ✨ 更新所有插件的 peerDependencies.umi 版本,兼容 4.x

### DIFF
--- a/example/plugin-layout/package.json
+++ b/example/plugin-layout/package.json
@@ -25,7 +25,7 @@
     "@umijs/plugin-initial-state": "2.x",
     "@umijs/plugin-locale": "0.x",
     "@umijs/plugin-model": "2.x",
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-access/package.json
+++ b/packages/plugin-access/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@umijs/plugin-initial-state": "2.x",
     "@umijs/plugin-model": "2.x",
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-analytics/package.json
+++ b/packages/plugin-analytics/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-analytics#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ant-design-pro-block/package.json
+++ b/packages/plugin-ant-design-pro-block/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-ant-design-pro-block#readme",
   "peerDependencies": {
     "@umijs/plugin-blocks": "2.x",
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-antd-dayjs/package.json
+++ b/packages/plugin-antd-dayjs/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-antd-dayjs#readme",
   "peerDependencies": {
     "dayjs": "*",
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-antd-mobile/package.json
+++ b/packages/plugin-antd-mobile/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-antd#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-antd/package.json
+++ b/packages/plugin-antd/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-antd#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-block-devtool/package.json
+++ b/packages/plugin-block-devtool/package.json
@@ -23,7 +23,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-block-devtool#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-crossorigin/package.json
+++ b/packages/plugin-crossorigin/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-crossorigin#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-dev-externals/package.json
+++ b/packages/plugin-dev-externals/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-dev-externals#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-dva/package.json
+++ b/packages/plugin-dva/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-dva#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-esbuild/package.json
+++ b/packages/plugin-esbuild/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-esbuild#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-helmet/package.json
+++ b/packages/plugin-helmet/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-helmet#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-initial-state/package.json
+++ b/packages/plugin-initial-state/package.json
@@ -23,7 +23,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-initial-state#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-layout/package.json
+++ b/packages/plugin-layout/package.json
@@ -30,7 +30,7 @@
     "@umijs/plugin-initial-state": "2.x",
     "@umijs/plugin-locale": "0.x",
     "@umijs/plugin-model": "2.x",
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-locale/package.json
+++ b/packages/plugin-locale/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-locale#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-model/package.json
+++ b/packages/plugin-model/package.json
@@ -23,7 +23,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-model#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-openapi/package.json
+++ b/packages/plugin-openapi/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-openapi#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -25,7 +25,7 @@
     "preact": "^10.5.7"
   },
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-request/package.json
+++ b/packages/plugin-request/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-request#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-sass#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-stylus#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-test/package.json
+++ b/packages/plugin-test/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/plugin-test#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-ant-design-pro/package.json
+++ b/packages/preset-ant-design-pro/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/preset-ant-design-pro#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-react/package.json
+++ b/packages/preset-react/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/preset-react#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-umi2-compatible/package.json
+++ b/packages/preset-umi2-compatible/package.json
@@ -22,7 +22,7 @@
   "bugs": "http://github.com/umijs/plugins/issues",
   "homepage": "https://github.com/umijs/plugins/tree/master/packages/preset-umi2-compatible#readme",
   "peerDependencies": {
-    "umi": "3.x"
+    "umi": ">= 3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
现在 umi 已经 4.x 了，这些插件的依赖还是 3.x ，在 tnpm install 的时候如果不加 `--legacy-peer-deps` 会报错，如下：

<img width="683" alt="image" src="https://user-images.githubusercontent.com/3724927/208565140-bf31bba2-044e-47a6-b5a2-a67ab27aba84.png">
