### PR TITLE
chore(preset-react): restore lost changes for 1.8.31

### DIFF
--- a/packages/preset-react/package.json
+++ b/packages/preset-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-react",
-  "version": "1.8.30",
+  "version": "1.8.31",
   "description": "@umijs/preset-react",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@umijs/plugin-access": "2.4.2",
+    "@umijs/plugin-access": "2.4.3",
     "@umijs/plugin-analytics": "0.2.2",
     "@umijs/plugin-antd": "0.13.0",
     "@umijs/plugin-crossorigin": "1.2.1",


### PR DESCRIPTION
`@umijs/preset-react@1.8.31` 的变更和 tag 都不在 GitHub 仓库里，通过 unpkg.com 对比产物做了手动恢复，以便继续 patch 发版