### PR TITLE
fix(preset-react): use locale 0.15.2 for check cookieEnable

### DIFF
--- a/packages/preset-react/package.json
+++ b/packages/preset-react/package.json
@@ -36,7 +36,7 @@
     "@umijs/plugin-helmet": "1.1.3",
     "@umijs/plugin-initial-state": "2.4.0",
     "@umijs/plugin-layout": "0.18.1",
-    "@umijs/plugin-locale": "0.15.1",
+    "@umijs/plugin-locale": "0.15.2",
     "@umijs/plugin-model": "2.6.2",
     "@umijs/plugin-request": "2.8.0",
     "@umijs/plugin-test": "1.0.2"


### PR DESCRIPTION
### 背景
Bigfish 3 一直在使用 `@umijs/preset-react@1.8.x`，但目前最新版锁定了 `@umijs/plugin-locale@0.15.1`，不包含 `cookieEnable` 检查的修复，在无痕浏览器下仍然访问 `LocalStorage` 可能会报错（取决于浏览器配置）

### 方案
单独切出 `preset-react-1.x` 分支，升级到 `@umijs/plugin-locale@0.15.2`，该版本仅包含这个修复 PR：https://github.com/umijs/plugins/pull/809