### PR TITLE
feat(plugin-locale):使国际化不仅限于[a-z]{2}${separator}[A-Z]{2}的格式

### DIFF
--- a/packages/plugin-locale/src/utils.ts
+++ b/packages/plugin-locale/src/utils.ts
@@ -81,7 +81,7 @@ export const getLocaleList = async (
     addAntdLocales,
   } = opts;
   const localeFileMath = new RegExp(
-    `^([a-z]{2})${separator}?([A-Z]{2})?\.(js|json|ts)$`,
+    `^([a-zA-Z]{0,})${separator}?([a-zA-Z]{0,})?\.(js|json|ts)$`,
   );
 
   const localeFiles = glob


### PR DESCRIPTION
使国际化不仅限于[a-z]{2}${separator}[A-Z]{2}的格式。主要是为了兼容部分应用场景，例如我遇到的问题，后端服务购买了ABP的商业版，此时为了便于维护，需要前后端对于多语言的键，例如常见的为 zh-CN，但ABP的为 zh-Hans，此时就导致插件无法识别 zh-Hans的多语言文件。
我认为不应该过于约束多语言文件的命名，或者说提供修改的方法。