### PR TITLE
feat(plugin-locale): add Burmese to language selector

### DIFF
--- a/packages/plugin-locale/src/templates/SelectLang.tpl
+++ b/packages/plugin-locale/src/templates/SelectLang.tpl
@@ -251,6 +251,12 @@ const defaultLangUConfigMap = {
     icon: '🇲🇰',
     title: 'Јазик'
   },
+  'mm-MM': {
+    lang: 'mm-MM',
+    label: 'မြန်မာ',
+    icon: '🇲🇲',
+    title: 'ဘာသာစကား'
+  },
   'mn-MN': {
     lang: 'mn-MN',
     label: 'Монгол хэл',


### PR DESCRIPTION
## Note

This PR is for replacing the old [PR](https://github.com/umijs/plugins/pull/906) which was mistakenly committed to the master branch that could bring the merge conflicts.

## Description
Add Burmese language to the language selector when Burmese localization is available.

There's already have Burmese language packs for react-components

https://github.com/react-component/picker/blob/master/src/locale/mm_MM.ts
https://github.com/react-component/pagination/blob/master/src/locale/mm_MM.js